### PR TITLE
Redesign menubar label with animated character and interactions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,14 @@ macOS 메뉴바 시스템 모니터 앱. "개구리 연못" 테마.
 ```
 🐸 개구리네 (FrogTrayApp)
 │
-├── 이마 (FrogMenuBarLabel) — 메뉴바에 항상 보이는 부분
-│   ├── 눈깔 (FrogStatusIcon) — 개구리 아이콘
-│   └── 이마글씨 — C/M/D 수치 텍스트
+├── 이마 (MenuBarLabelView) — 메뉴바에 항상 보이는 부분
+│   ├── 눈깔 (MenuBarCharacterView) — 개구리 캐릭터 (SF Symbol 애니메이션)
+│   ├── 이마글씨 — C/M/D 수치 텍스트
+│   └── 이마막대 (MenuBarHistoryBarsView) — 히스토리 막대 그래프
+│
+├── 다리 (MenuBarHostingBridge) — AppKit 브릿지 (호버/우클릭/팝오버)
+│   ├── 말풍선 (MenuBarTooltipView) — 호버 시 팝오버 툴팁
+│   └── 메뉴판 (MenuBarContextMenu) — 우클릭 컨텍스트 메뉴
 │
 └── 배 (ContentView) — 클릭 시 열리는 트레이 윈도우
     │

--- a/FrogTray/FrogTray/ContentView.swift
+++ b/FrogTray/FrogTray/ContentView.swift
@@ -30,29 +30,6 @@ enum TrayScreen: Equatable {
     }
 }
 
-// MARK: - Pond Theme
-
-enum PondTheme {
-    static let pondDeep = Color(hue: 0.48, saturation: 0.55, brightness: 0.30)
-    static let pondMid = Color(hue: 0.46, saturation: 0.40, brightness: 0.50)
-    static let pondSurface = Color(hue: 0.44, saturation: 0.30, brightness: 0.65)
-    static let lilyPadGreen = Color(hue: 0.35, saturation: 0.35, brightness: 0.55)
-    static let lilyPadLight = Color(hue: 0.33, saturation: 0.20, brightness: 0.75)
-    static let mossFern = Color(hue: 0.30, saturation: 0.45, brightness: 0.40)
-
-    static let pondGradient = LinearGradient(
-        colors: [pondDeep, pondMid, pondSurface.opacity(0.3)],
-        startPoint: .bottom,
-        endPoint: .top
-    )
-
-    static let lilyPadGradient = LinearGradient(
-        colors: [lilyPadGreen.opacity(0.08), lilyPadLight.opacity(0.04)],
-        startPoint: .bottomLeading,
-        endPoint: .topTrailing
-    )
-}
-
 // MARK: - ContentView
 
 struct ContentView: View {
@@ -530,46 +507,49 @@ private struct InlineStatusMessage: View {
     }
 }
 
-// MARK: - Tone Enums
+// MARK: - FrogStatusIcon (inline, used in summaryCard)
 
-enum UsageTone {
-    case stable
-    case caution
-    case critical
+private struct FrogStatusIcon: View {
+    let state: FrogBellyState
 
-    init(value: Double) {
-        switch value {
-        case 0.85...:
-            self = .critical
-        case 0.65...:
-            self = .caution
-        default:
-            self = .stable
+    private var bellySize: CGSize {
+        switch state {
+        case .calm:
+            CGSize(width: 5, height: 3.5)
+        case .normal:
+            CGSize(width: 6.5, height: 5)
+        case .warning:
+            CGSize(width: 8, height: 6.5)
+        case .critical:
+            CGSize(width: 9.5, height: 8)
         }
     }
 
-    var color: Color {
-        switch self {
-        case .stable:
-            return Color(hue: 0.48, saturation: 0.65, brightness: 0.75)
-        case .caution:
-            return Color(hue: 0.10, saturation: 0.70, brightness: 0.85)
-        case .critical:
-            return Color(hue: 0.02, saturation: 0.60, brightness: 0.90)
-        }
-    }
+    var body: some View {
+        ZStack {
+            HStack(spacing: 4) {
+                Circle()
+                    .frame(width: 4, height: 4)
+                Circle()
+                    .frame(width: 4, height: 4)
+            }
+            .offset(y: -4.5)
 
-    var badgeTitle: String {
-        switch self {
-        case .stable:
-            return "잔잔"
-        case .caution:
-            return "출렁"
-        case .critical:
-            return "넘침"
+            Capsule(style: .continuous)
+                .frame(width: 11, height: 8)
+                .offset(y: 0.5)
+
+            Ellipse()
+                .frame(width: bellySize.width, height: bellySize.height)
+                .offset(x: 1.5, y: 3.5)
         }
+        .frame(width: 16, height: 14)
+        .foregroundStyle(.primary)
+        .accessibilityHidden(true)
     }
 }
+
+// MARK: - StatusTone
 
 private enum StatusTone {
     case positive

--- a/FrogTray/FrogTray/FrogTrayApp.swift
+++ b/FrogTray/FrogTray/FrogTrayApp.swift
@@ -21,66 +21,12 @@ struct FrogTrayApp: App {
                 processMonitor: processMonitor
             )
         } label: {
-            FrogMenuBarLabel(snapshot: metricsMonitor.snapshot)
+            MenuBarLabelView(
+                monitor: metricsMonitor,
+                launchAtLoginManager: launchAtLoginManager,
+                processMonitor: processMonitor
+            )
         }
         .menuBarExtraStyle(.window)
-    }
-}
-
-private struct FrogMenuBarLabel: View {
-    let snapshot: SystemSnapshot
-
-    var body: some View {
-        HStack(spacing: 4) {
-            FrogStatusIcon(state: snapshot.frogBellyState)
-
-            Text(snapshot.menuBarMetricsText)
-                .font(.system(size: 11, weight: .semibold, design: .rounded))
-                .monospacedDigit()
-                .lineLimit(1)
-        }
-        .fixedSize(horizontal: true, vertical: false)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(snapshot.menuBarAccessibilityText)
-    }
-}
-
-struct FrogStatusIcon: View {
-    let state: FrogBellyState
-
-    private var bellySize: CGSize {
-        switch state {
-        case .calm:
-            CGSize(width: 5, height: 3.5)
-        case .normal:
-            CGSize(width: 6.5, height: 5)
-        case .warning:
-            CGSize(width: 8, height: 6.5)
-        case .critical:
-            CGSize(width: 9.5, height: 8)
-        }
-    }
-
-    var body: some View {
-        ZStack {
-            HStack(spacing: 4) {
-                Circle()
-                    .frame(width: 4, height: 4)
-                Circle()
-                    .frame(width: 4, height: 4)
-            }
-            .offset(y: -4.5)
-
-            Capsule(style: .continuous)
-                .frame(width: 11, height: 8)
-                .offset(y: 0.5)
-
-            Ellipse()
-                .frame(width: bellySize.width, height: bellySize.height)
-                .offset(x: 1.5, y: 3.5)
-        }
-        .frame(width: 16, height: 14)
-        .foregroundStyle(.primary)
-        .accessibilityHidden(true)
     }
 }

--- a/FrogTray/FrogTray/MenuBarCharacterView.swift
+++ b/FrogTray/FrogTray/MenuBarCharacterView.swift
@@ -1,0 +1,111 @@
+//
+//  MenuBarCharacterView.swift
+//  FrogTray
+//
+//  Animated SF Symbol character for the menu bar.
+//  Includes breathing, blinking, state-specific motion, and symbol morphing.
+//
+
+import SwiftUI
+
+struct MenuBarCharacterView: View {
+    let state: PondState
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    @State private var breathPhase = false
+    @State private var isBlinking = false
+    @State private var motionPhase = false
+    @State private var blinkTask: Task<Void, Never>?
+
+    var body: some View {
+        Image(systemName: state.sfSymbolName)
+            .font(.system(size: 14, weight: .medium))
+            .symbolRenderingMode(.hierarchical)
+            .foregroundStyle(characterColor)
+            .scaleEffect(animatedScale)
+            .opacity(isBlinking ? 0.3 : 1.0)
+            .modifier(StateMotionModifier(state: state, active: motionPhase))
+            .contentTransition(.symbolEffect(.replace.byLayer))
+            .frame(width: 18, height: 16)
+            .onAppear { startAnimations() }
+            .onDisappear { stopAnimations() }
+            .accessibilityHidden(true)
+    }
+
+    // MARK: - Computed
+
+    private var characterColor: Color {
+        switch state {
+        case .sleeping:
+            return PondTheme.characterAccent(for: colorScheme)
+        case .danger:
+            return UsageTone.critical.color
+        case .caution:
+            return UsageTone.caution.color
+        default:
+            return PondTheme.characterTint(for: colorScheme)
+        }
+    }
+
+    private var animatedScale: CGFloat {
+        guard !reduceMotion else { return 1.0 }
+        let base: CGFloat = breathPhase ? 1.05 : 1.0
+        return state == .danger ? base * 1.08 : base
+    }
+
+    // MARK: - Animations
+
+    private func startAnimations() {
+        guard !reduceMotion else { return }
+
+        withAnimation(.easeInOut(duration: 3).repeatForever(autoreverses: true)) {
+            breathPhase = true
+        }
+
+        withAnimation(.easeInOut(duration: 2).repeatForever(autoreverses: true)) {
+            motionPhase = true
+        }
+
+        blinkTask = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(Double.random(in: 4...6)))
+                guard !Task.isCancelled else { break }
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    isBlinking = true
+                }
+                try? await Task.sleep(for: .milliseconds(150))
+                guard !Task.isCancelled else { break }
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    isBlinking = false
+                }
+            }
+        }
+    }
+
+    private func stopAnimations() {
+        blinkTask?.cancel()
+        blinkTask = nil
+    }
+}
+
+// MARK: - State Motion Modifier
+
+private struct StateMotionModifier: ViewModifier {
+    let state: PondState
+    let active: Bool
+
+    func body(content: Content) -> some View {
+        let phase = active ? 1.0 : 0.0
+        switch state {
+        case .sleeping:
+            content.offset(y: phase * 1.5)
+        case .caution:
+            content.rotationEffect(.degrees(phase * 4 - 2))
+        case .danger:
+            content.rotationEffect(.degrees(phase * 10 - 5))
+        default:
+            content
+        }
+    }
+}

--- a/FrogTray/FrogTray/MenuBarCharacterView.swift
+++ b/FrogTray/FrogTray/MenuBarCharacterView.swift
@@ -68,17 +68,21 @@ struct MenuBarCharacterView: View {
         }
 
         blinkTask = Task {
-            while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(Double.random(in: 4...6)))
-                guard !Task.isCancelled else { break }
-                withAnimation(.easeInOut(duration: 0.15)) {
-                    isBlinking = true
+            do {
+                while !Task.isCancelled {
+                    try await Task.sleep(for: .seconds(Double.random(in: 4...6)))
+                    withAnimation(.easeInOut(duration: 0.15)) {
+                        isBlinking = true
+                    }
+                    try await Task.sleep(for: .milliseconds(150))
+                    withAnimation(.easeInOut(duration: 0.15)) {
+                        isBlinking = false
+                    }
                 }
-                try? await Task.sleep(for: .milliseconds(150))
-                guard !Task.isCancelled else { break }
-                withAnimation(.easeInOut(duration: 0.15)) {
-                    isBlinking = false
-                }
+            } catch is CancellationError {
+                // Expected when stopAnimations() cancels the task
+            } catch {
+                // Unexpected error; stop blinking gracefully
             }
         }
     }

--- a/FrogTray/FrogTray/MenuBarContextMenu.swift
+++ b/FrogTray/FrogTray/MenuBarContextMenu.swift
@@ -1,0 +1,133 @@
+//
+//  MenuBarContextMenu.swift
+//  FrogTray
+//
+//  NSMenu builder for right-click on the menu bar item.
+//
+
+import AppKit
+
+final class MenuBarContextMenu {
+    private let monitor: SystemMetricsMonitor
+    private let launchAtLoginManager: LaunchAtLoginManager
+    private let processMonitor: ProcessMonitor
+    private let onRefresh: () -> Void
+
+    init(
+        monitor: SystemMetricsMonitor,
+        launchAtLoginManager: LaunchAtLoginManager,
+        processMonitor: ProcessMonitor,
+        onRefresh: @escaping () -> Void
+    ) {
+        self.monitor = monitor
+        self.launchAtLoginManager = launchAtLoginManager
+        self.processMonitor = processMonitor
+        self.onRefresh = onRefresh
+    }
+
+    func buildMenu() -> NSMenu {
+        let menu = NSMenu()
+
+        // Summary header
+        let snapshot = monitor.snapshot
+        let state = PondState(snapshot: snapshot)
+        let headerItem = NSMenuItem(title: "\(state.storyTitle) — \(snapshot.menuBarMetricsText)", action: nil, keyEquivalent: "")
+        headerItem.isEnabled = false
+        menu.addItem(headerItem)
+
+        menu.addItem(.separator())
+
+        // Metrics summary
+        addMetricItem(to: menu, label: "CPU", value: snapshot.cpuUsage)
+        addMetricItem(to: menu, label: "Memory", value: snapshot.memoryUsage)
+        addMetricItem(to: menu, label: "Disk", value: snapshot.diskUsage)
+
+        menu.addItem(.separator())
+
+        // Top processes
+        let processesItem = NSMenuItem(title: "주요 프로세스", action: nil, keyEquivalent: "")
+        processesItem.isEnabled = false
+        menu.addItem(processesItem)
+
+        for process in processMonitor.topCPUProcesses.prefix(3) {
+            let item = NSMenuItem(
+                title: "  \(process.displayName) — CPU \(String(format: "%.1f%%", process.totalCPUUsage))",
+                action: nil,
+                keyEquivalent: ""
+            )
+            item.isEnabled = false
+            menu.addItem(item)
+        }
+
+        menu.addItem(.separator())
+
+        // Launch at login toggle
+        let loginItem = NSMenuItem(
+            title: "로그인 시 자동 실행",
+            action: #selector(toggleLaunchAtLogin),
+            keyEquivalent: ""
+        )
+        loginItem.target = self
+        loginItem.state = launchAtLoginManager.isEnabled ? .on : .off
+        menu.addItem(loginItem)
+
+        // System settings
+        let settingsItem = NSMenuItem(
+            title: "시스템 설정…",
+            action: #selector(openSystemSettings),
+            keyEquivalent: ","
+        )
+        settingsItem.target = self
+        menu.addItem(settingsItem)
+
+        menu.addItem(.separator())
+
+        // Refresh
+        let refreshItem = NSMenuItem(
+            title: "새로고침",
+            action: #selector(handleRefresh),
+            keyEquivalent: "r"
+        )
+        refreshItem.target = self
+        menu.addItem(refreshItem)
+
+        // Quit
+        let quitItem = NSMenuItem(
+            title: "종료",
+            action: #selector(handleQuit),
+            keyEquivalent: "q"
+        )
+        quitItem.target = self
+        menu.addItem(quitItem)
+
+        return menu
+    }
+
+    private func addMetricItem(to menu: NSMenu, label: String, value: Double) {
+        let tone = UsageTone(value: value)
+        let percentage = Int((max(0, min(value, 1)) * 100).rounded())
+        let item = NSMenuItem(
+            title: "\(label): \(percentage)% — \(tone.badgeTitle)",
+            action: nil,
+            keyEquivalent: ""
+        )
+        item.isEnabled = false
+        menu.addItem(item)
+    }
+
+    @objc private func toggleLaunchAtLogin() {
+        launchAtLoginManager.setLaunchAtLoginEnabled(!launchAtLoginManager.isEnabled)
+    }
+
+    @objc private func openSystemSettings() {
+        launchAtLoginManager.openSystemSettingsLoginItems()
+    }
+
+    @objc private func handleRefresh() {
+        onRefresh()
+    }
+
+    @objc private func handleQuit() {
+        NSApplication.shared.terminate(nil)
+    }
+}

--- a/FrogTray/FrogTray/MenuBarHistoryBarsView.swift
+++ b/FrogTray/FrogTray/MenuBarHistoryBarsView.swift
@@ -1,0 +1,58 @@
+//
+//  MenuBarHistoryBarsView.swift
+//  FrogTray
+//
+//  Mini bar graph showing recent 3 readings for CPU/Memory/Disk.
+//  Replaces the old "C32 M67 D74" text label.
+//
+
+import SwiftUI
+
+struct MenuBarHistoryBarsView: View {
+    let history: MetricsHistory
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private let barWidth: CGFloat = 3
+    private let barSpacing: CGFloat = 1
+    private let groupSpacing: CGFloat = 3
+    private let maxBarHeight: CGFloat = 12
+    private let labelFont = Font.system(size: 7, weight: .bold, design: .rounded)
+
+    var body: some View {
+        HStack(spacing: groupSpacing) {
+            metricGroup(label: "C", values: history.cpuValues)
+            metricGroup(label: "M", values: history.memoryValues)
+            metricGroup(label: "D", values: history.diskValues)
+        }
+        .frame(height: 16)
+        .accessibilityHidden(true)
+    }
+
+    private func metricGroup(label: String, values: [Double]) -> some View {
+        VStack(spacing: 1) {
+            HStack(spacing: barSpacing) {
+                ForEach(0..<3, id: \.self) { index in
+                    let value = index < values.count ? values[index] : 0
+                    singleBar(value: value)
+                }
+            }
+            .frame(height: maxBarHeight)
+
+            Text(label)
+                .font(labelFont)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func singleBar(value: Double) -> some View {
+        let tone = UsageTone(value: value)
+        let height = max(1, maxBarHeight * CGFloat(value))
+        return VStack {
+            Spacer(minLength: 0)
+            RoundedRectangle(cornerRadius: 1)
+                .fill(tone.color)
+                .frame(width: barWidth, height: height)
+                .animation(reduceMotion ? nil : .easeOut(duration: 0.3), value: value)
+        }
+    }
+}

--- a/FrogTray/FrogTray/MenuBarHostingBridge.swift
+++ b/FrogTray/FrogTray/MenuBarHostingBridge.swift
@@ -8,7 +8,10 @@
 //
 
 import AppKit
+import os
 import SwiftUI
+
+private let logger = Logger(subsystem: "com.oozoofrog.FrogTray", category: "MenuBarHostingBridge")
 
 struct MenuBarHostingBridge: NSViewRepresentable {
     @ObservedObject var monitor: SystemMetricsMonitor
@@ -46,6 +49,7 @@ struct MenuBarHostingBridge: NSViewRepresentable {
         var popover: NSPopover?
         var contextMenuBuilder: MenuBarContextMenu?
         var isHovering = false
+        private var hoverTimer: Timer?
 
         init(
             monitor: SystemMetricsMonitor,
@@ -85,11 +89,17 @@ struct MenuBarHostingBridge: NSViewRepresentable {
 
         @objc func mouseEntered(with event: NSEvent) {
             isHovering = true
-            showTooltipPopover()
+            hoverTimer?.invalidate()
+            hoverTimer = Timer.scheduledTimer(withTimeInterval: 0.4, repeats: false) { [weak self] _ in
+                guard let self, self.isHovering else { return }
+                self.showTooltipPopover()
+            }
         }
 
         @objc func mouseExited(with event: NSEvent) {
             isHovering = false
+            hoverTimer?.invalidate()
+            hoverTimer = nil
             dismissTooltipPopover()
         }
 
@@ -99,12 +109,12 @@ struct MenuBarHostingBridge: NSViewRepresentable {
 
             let menu = contextMenuBuilder.buildMenu()
 
-            // Standard pattern: temporarily set the menu, then remove it
-            // so left-click still opens the SwiftUI window
+            // Temporarily assign the menu to the status item so NSStatusBarButton
+            // presents it on the next performClick. Clear it afterward so that
+            // subsequent left-clicks still open the SwiftUI popover window.
             if let statusItem = button.statusItem {
                 statusItem.menu = menu
                 button.performClick(nil)
-                // Remove menu after it closes so left-click works again
                 DispatchQueue.main.async {
                     statusItem.menu = nil
                 }
@@ -155,11 +165,14 @@ final class BridgeAnchorView: NSView {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
+        guard window != nil else { return }
         guard !didSetup else { return }
 
         if let button = findStatusBarButton() {
             coordinator?.setupOnButton(button)
             didSetup = true
+        } else {
+            logger.warning("findStatusBarButton() failed — NSStatusBarButton ancestor not found")
         }
     }
 
@@ -175,7 +188,11 @@ final class BridgeAnchorView: NSView {
     }
 
     override func rightMouseDown(with event: NSEvent) {
-        coordinator?.showRightClickMenu()
+        guard let coordinator else {
+            super.rightMouseDown(with: event)
+            return
+        }
+        coordinator.showRightClickMenu()
     }
 }
 
@@ -183,9 +200,15 @@ final class BridgeAnchorView: NSView {
 
 private extension NSStatusBarButton {
     var statusItem: NSStatusItem? {
-        // Walk up the responder chain to find the status item
-        // The button's window is NSStatusBarWindow, which has a reference
+        // Access the status item via KVC on NSStatusBarWindow (private API).
+        // Guard with responds(to:) to avoid NSUnknownKeyException if the
+        // internal key is removed in a future macOS release.
         guard let window = self.window else { return nil }
+        let selector = NSSelectorFromString("statusItem")
+        guard window.responds(to: selector) else {
+            logger.warning("NSStatusBarWindow no longer responds to 'statusItem' KVC key")
+            return nil
+        }
         return window.value(forKey: "statusItem") as? NSStatusItem
     }
 }

--- a/FrogTray/FrogTray/MenuBarHostingBridge.swift
+++ b/FrogTray/FrogTray/MenuBarHostingBridge.swift
@@ -1,0 +1,191 @@
+//
+//  MenuBarHostingBridge.swift
+//  FrogTray
+//
+//  AppKit bridge embedded in the menu bar label.
+//  Provides hover detection, tooltip popover, and right-click context menu
+//  by walking up to the NSStatusBarButton ancestor.
+//
+
+import AppKit
+import SwiftUI
+
+struct MenuBarHostingBridge: NSViewRepresentable {
+    @ObservedObject var monitor: SystemMetricsMonitor
+    @ObservedObject var launchAtLoginManager: LaunchAtLoginManager
+    @ObservedObject var processMonitor: ProcessMonitor
+
+    func makeNSView(context: Context) -> BridgeAnchorView {
+        let view = BridgeAnchorView()
+        view.coordinator = context.coordinator
+        return view
+    }
+
+    func updateNSView(_ nsView: BridgeAnchorView, context: Context) {
+        context.coordinator.monitor = monitor
+        context.coordinator.launchAtLoginManager = launchAtLoginManager
+        context.coordinator.processMonitor = processMonitor
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(
+            monitor: monitor,
+            launchAtLoginManager: launchAtLoginManager,
+            processMonitor: processMonitor
+        )
+    }
+
+    // MARK: - Coordinator
+
+    final class Coordinator: NSObject, NSPopoverDelegate {
+        var monitor: SystemMetricsMonitor
+        var launchAtLoginManager: LaunchAtLoginManager
+        var processMonitor: ProcessMonitor
+
+        weak var statusBarButton: NSStatusBarButton?
+        var popover: NSPopover?
+        var contextMenuBuilder: MenuBarContextMenu?
+        var isHovering = false
+
+        init(
+            monitor: SystemMetricsMonitor,
+            launchAtLoginManager: LaunchAtLoginManager,
+            processMonitor: ProcessMonitor
+        ) {
+            self.monitor = monitor
+            self.launchAtLoginManager = launchAtLoginManager
+            self.processMonitor = processMonitor
+        }
+
+        func setupOnButton(_ button: NSStatusBarButton) {
+            self.statusBarButton = button
+
+            contextMenuBuilder = MenuBarContextMenu(
+                monitor: monitor,
+                launchAtLoginManager: launchAtLoginManager,
+                processMonitor: processMonitor,
+                onRefresh: { [weak self] in
+                    self?.monitor.refresh()
+                    self?.processMonitor.refresh()
+                    self?.launchAtLoginManager.refresh()
+                }
+            )
+
+            // Add tracking area for hover
+            let trackingArea = NSTrackingArea(
+                rect: .zero,
+                options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+                owner: self,
+                userInfo: nil
+            )
+            button.addTrackingArea(trackingArea)
+        }
+
+        // MARK: - Mouse Events
+
+        @objc func mouseEntered(with event: NSEvent) {
+            isHovering = true
+            showTooltipPopover()
+        }
+
+        @objc func mouseExited(with event: NSEvent) {
+            isHovering = false
+            dismissTooltipPopover()
+        }
+
+        func showRightClickMenu() {
+            guard let button = statusBarButton,
+                  let contextMenuBuilder else { return }
+
+            let menu = contextMenuBuilder.buildMenu()
+
+            // Standard pattern: temporarily set the menu, then remove it
+            // so left-click still opens the SwiftUI window
+            if let statusItem = button.statusItem {
+                statusItem.menu = menu
+                button.performClick(nil)
+                // Remove menu after it closes so left-click works again
+                DispatchQueue.main.async {
+                    statusItem.menu = nil
+                }
+            }
+        }
+
+        // MARK: - Tooltip Popover
+
+        private func showTooltipPopover() {
+            guard let button = statusBarButton else { return }
+            guard popover == nil else { return }
+
+            let tooltipView = MenuBarTooltipView(
+                snapshot: monitor.snapshot,
+                state: PondState(snapshot: monitor.snapshot)
+            )
+
+            let popover = NSPopover()
+            popover.contentViewController = NSHostingController(rootView: tooltipView)
+            popover.behavior = .transient
+            popover.delegate = self
+            popover.animates = true
+
+            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+            self.popover = popover
+        }
+
+        private func dismissTooltipPopover() {
+            popover?.performClose(nil)
+            popover = nil
+        }
+
+        // MARK: - NSPopoverDelegate
+
+        nonisolated func popoverDidClose(_ notification: Notification) {
+            Task { @MainActor in
+                self.popover = nil
+            }
+        }
+    }
+}
+
+// MARK: - BridgeAnchorView
+
+final class BridgeAnchorView: NSView {
+    weak var coordinator: MenuBarHostingBridge.Coordinator?
+    private var didSetup = false
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard !didSetup else { return }
+
+        if let button = findStatusBarButton() {
+            coordinator?.setupOnButton(button)
+            didSetup = true
+        }
+    }
+
+    private func findStatusBarButton() -> NSStatusBarButton? {
+        var current: NSView? = self
+        while let view = current {
+            if let button = view as? NSStatusBarButton {
+                return button
+            }
+            current = view.superview
+        }
+        return nil
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+        coordinator?.showRightClickMenu()
+    }
+}
+
+// MARK: - NSStatusBarButton Extension
+
+private extension NSStatusBarButton {
+    var statusItem: NSStatusItem? {
+        // Walk up the responder chain to find the status item
+        // The button's window is NSStatusBarWindow, which has a reference
+        guard let window = self.window else { return nil }
+        return window.value(forKey: "statusItem") as? NSStatusItem
+    }
+}

--- a/FrogTray/FrogTray/MenuBarLabelView.swift
+++ b/FrogTray/FrogTray/MenuBarLabelView.swift
@@ -1,0 +1,37 @@
+//
+//  MenuBarLabelView.swift
+//  FrogTray
+//
+//  Combined menu bar label: animated character + history bars + AppKit bridge.
+//
+
+import SwiftUI
+
+struct MenuBarLabelView: View {
+    @ObservedObject var monitor: SystemMetricsMonitor
+    @ObservedObject var launchAtLoginManager: LaunchAtLoginManager
+    @ObservedObject var processMonitor: ProcessMonitor
+
+    var body: some View {
+        HStack(spacing: 4) {
+            MenuBarCharacterView(state: monitor.pondState)
+
+            MenuBarHistoryBarsView(history: monitor.metricsHistory)
+
+            MenuBarHostingBridge(
+                monitor: monitor,
+                launchAtLoginManager: launchAtLoginManager,
+                processMonitor: processMonitor
+            )
+            .frame(width: 0, height: 0)
+        }
+        .fixedSize(horizontal: true, vertical: false)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityText)
+        .accessibilityValue(monitor.pondState.accessibilityDescription)
+    }
+
+    private var accessibilityText: String {
+        monitor.snapshot.menuBarAccessibilityText
+    }
+}

--- a/FrogTray/FrogTray/MenuBarTooltipView.swift
+++ b/FrogTray/FrogTray/MenuBarTooltipView.swift
@@ -1,0 +1,76 @@
+//
+//  MenuBarTooltipView.swift
+//  FrogTray
+//
+//  Mini dashboard shown in NSPopover on hover.
+//
+
+import SwiftUI
+
+struct MenuBarTooltipView: View {
+    let snapshot: SystemSnapshot
+    let state: PondState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Image(systemName: state.sfSymbolName)
+                    .font(.title3)
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(characterColor)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(state.storyTitle)
+                        .font(.headline)
+
+                    Text(snapshot.lastUpdated.formatted(date: .omitted, time: .shortened))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Divider()
+
+            tooltipRow(label: "CPU", value: snapshot.cpuUsage)
+            tooltipRow(label: "Memory", value: snapshot.memoryUsage, detail: "\(snapshot.memoryUsedText) / \(snapshot.memoryTotalText)")
+            tooltipRow(label: "Disk", value: snapshot.diskUsage, detail: "\(snapshot.diskUsedText) / \(snapshot.diskTotalText)")
+        }
+        .padding(12)
+        .frame(width: 220)
+    }
+
+    private var characterColor: Color {
+        switch state {
+        case .danger: UsageTone.critical.color
+        case .caution: UsageTone.caution.color
+        default: PondTheme.lilyPadGreen
+        }
+    }
+
+    private func tooltipRow(label: String, value: Double, detail: String? = nil) -> some View {
+        let tone = UsageTone(value: value)
+        return HStack {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(width: 50, alignment: .leading)
+
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    Capsule(style: .continuous)
+                        .fill(tone.color.opacity(0.15))
+
+                    Capsule(style: .continuous)
+                        .fill(tone.color)
+                        .frame(width: max(0, geo.size.width * CGFloat(value)))
+                }
+            }
+            .frame(height: 6)
+            .clipShape(Capsule(style: .continuous))
+
+            Text(value.percentText)
+                .font(.caption.monospacedDigit().bold())
+                .frame(width: 36, alignment: .trailing)
+        }
+    }
+}

--- a/FrogTray/FrogTray/MetricsHistory.swift
+++ b/FrogTray/FrogTray/MetricsHistory.swift
@@ -2,7 +2,7 @@
 //  MetricsHistory.swift
 //  FrogTray
 //
-//  Circular buffer storing the last 3 metric readings for the history bar graph.
+//  Bounded queue storing the last 3 metric readings for the history bar graph.
 //
 
 import Foundation
@@ -14,11 +14,16 @@ struct MetricsHistory: Sendable {
         let disk: Double
     }
 
-    private(set) var readings: [Reading] = []
+    private var readings: [Reading] = []
     private let capacity = 3
 
     mutating func push(cpu: Double, memory: Double, disk: Double) {
-        readings.append(Reading(cpu: cpu, memory: memory, disk: disk))
+        let clamped = Reading(
+            cpu: min(max(cpu, 0), 1),
+            memory: min(max(memory, 0), 1),
+            disk: min(max(disk, 0), 1)
+        )
+        readings.append(clamped)
         if readings.count > capacity {
             readings.removeFirst()
         }

--- a/FrogTray/FrogTray/MetricsHistory.swift
+++ b/FrogTray/FrogTray/MetricsHistory.swift
@@ -1,0 +1,30 @@
+//
+//  MetricsHistory.swift
+//  FrogTray
+//
+//  Circular buffer storing the last 3 metric readings for the history bar graph.
+//
+
+import Foundation
+
+struct MetricsHistory: Sendable {
+    struct Reading: Sendable {
+        let cpu: Double
+        let memory: Double
+        let disk: Double
+    }
+
+    private(set) var readings: [Reading] = []
+    private let capacity = 3
+
+    mutating func push(cpu: Double, memory: Double, disk: Double) {
+        readings.append(Reading(cpu: cpu, memory: memory, disk: disk))
+        if readings.count > capacity {
+            readings.removeFirst()
+        }
+    }
+
+    var cpuValues: [Double] { readings.map(\.cpu) }
+    var memoryValues: [Double] { readings.map(\.memory) }
+    var diskValues: [Double] { readings.map(\.disk) }
+}

--- a/FrogTray/FrogTray/PondState.swift
+++ b/FrogTray/FrogTray/PondState.swift
@@ -1,0 +1,73 @@
+//
+//  PondState.swift
+//  FrogTray
+//
+//  6-stage pond state model with SF Symbol mapping.
+//
+
+import SwiftUI
+
+enum PondState: String, CaseIterable, Sendable {
+    case sleeping   // CPU<10%, MEM<30%, DSK<30%
+    case relaxed    // default 0-39%
+    case normal     // 40-64%
+    case caution    // 65-84%
+    case danger     // 85%+
+    case loading    // no data yet
+
+    init(snapshot: SystemSnapshot) {
+        guard snapshot.cpuDetail != nil || snapshot.memoryDetail != nil else {
+            self = .loading
+            return
+        }
+
+        if snapshot.cpuUsage < 0.10 && snapshot.memoryUsage < 0.30 && snapshot.diskUsage < 0.30 {
+            self = .sleeping
+            return
+        }
+
+        switch snapshot.worstUsage {
+        case 0.85...:
+            self = .danger
+        case 0.65...:
+            self = .caution
+        case 0.40...:
+            self = .normal
+        default:
+            self = .relaxed
+        }
+    }
+
+    var sfSymbolName: String {
+        switch self {
+        case .sleeping: "moon.zzz.fill"
+        case .relaxed:  "leaf.fill"
+        case .normal:   "cloud.fill"
+        case .caution:  "cloud.bolt.fill"
+        case .danger:   "tornado"
+        case .loading:  "ellipsis.circle"
+        }
+    }
+
+    var storyTitle: String {
+        switch self {
+        case .sleeping: "고요한 밤 연못"
+        case .relaxed:  "맑은 연못"
+        case .normal:   "흐린 연못"
+        case .caution:  "폭풍우 연못"
+        case .danger:   "토네이도 연못"
+        case .loading:  "연못 관찰 중"
+        }
+    }
+
+    var accessibilityDescription: String {
+        switch self {
+        case .sleeping: "시스템이 매우 여유롭습니다. 잠자기 상태"
+        case .relaxed:  "시스템이 여유롭습니다"
+        case .normal:   "시스템 사용량이 보통입니다"
+        case .caution:  "시스템 사용량에 주의가 필요합니다"
+        case .danger:   "시스템 사용량이 위험 수준입니다"
+        case .loading:  "시스템 정보를 불러오는 중입니다"
+        }
+    }
+}

--- a/FrogTray/FrogTray/PondTheme.swift
+++ b/FrogTray/FrogTray/PondTheme.swift
@@ -1,0 +1,87 @@
+//
+//  PondTheme.swift
+//  FrogTray
+//
+//  Extracted from ContentView.swift — shared color palette + usage tone.
+//
+
+import SwiftUI
+
+// MARK: - PondTheme
+
+enum PondTheme {
+    // Day pond colors
+    static let pondDeep = Color(hue: 0.48, saturation: 0.55, brightness: 0.30)
+    static let pondMid = Color(hue: 0.46, saturation: 0.40, brightness: 0.50)
+    static let pondSurface = Color(hue: 0.44, saturation: 0.30, brightness: 0.65)
+    static let lilyPadGreen = Color(hue: 0.35, saturation: 0.35, brightness: 0.55)
+    static let lilyPadLight = Color(hue: 0.33, saturation: 0.20, brightness: 0.75)
+    static let mossFern = Color(hue: 0.30, saturation: 0.45, brightness: 0.40)
+
+    // Night pond colors (dark mode)
+    static let nightDeep = Color(hue: 0.62, saturation: 0.60, brightness: 0.20)
+    static let nightMid = Color(hue: 0.60, saturation: 0.45, brightness: 0.35)
+    static let moonlightSilver = Color(hue: 0.55, saturation: 0.08, brightness: 0.82)
+    static let starGlow = Color(hue: 0.15, saturation: 0.20, brightness: 0.90)
+
+    static let pondGradient = LinearGradient(
+        colors: [pondDeep, pondMid, pondSurface.opacity(0.3)],
+        startPoint: .bottom,
+        endPoint: .top
+    )
+
+    static let lilyPadGradient = LinearGradient(
+        colors: [lilyPadGreen.opacity(0.08), lilyPadLight.opacity(0.04)],
+        startPoint: .bottomLeading,
+        endPoint: .topTrailing
+    )
+
+    static func characterTint(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? moonlightSilver : lilyPadGreen
+    }
+
+    static func characterAccent(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? starGlow : pondSurface
+    }
+}
+
+// MARK: - UsageTone
+
+enum UsageTone {
+    case stable
+    case caution
+    case critical
+
+    init(value: Double) {
+        switch value {
+        case 0.85...:
+            self = .critical
+        case 0.65...:
+            self = .caution
+        default:
+            self = .stable
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .stable:
+            return Color(hue: 0.48, saturation: 0.65, brightness: 0.75)
+        case .caution:
+            return Color(hue: 0.10, saturation: 0.70, brightness: 0.85)
+        case .critical:
+            return Color(hue: 0.02, saturation: 0.60, brightness: 0.90)
+        }
+    }
+
+    var badgeTitle: String {
+        switch self {
+        case .stable:
+            return "잔잔"
+        case .caution:
+            return "출렁"
+        case .critical:
+            return "넘침"
+        }
+    }
+}

--- a/FrogTray/FrogTray/SystemMetricsMonitor.swift
+++ b/FrogTray/FrogTray/SystemMetricsMonitor.swift
@@ -111,6 +111,9 @@ struct SystemSnapshot {
 @MainActor
 final class SystemMetricsMonitor: ObservableObject {
     @Published private(set) var snapshot = SystemSnapshot.placeholder
+    @Published private(set) var metricsHistory = MetricsHistory()
+
+    var pondState: PondState { PondState(snapshot: snapshot) }
 
     private var timerCancellable: AnyCancellable?
     private var previousCPUTicks: [UInt32]?
@@ -159,6 +162,12 @@ final class SystemMetricsMonitor: ObservableObject {
             cpuDetail: cpuDetail,
             memoryDetail: memorySample.detail,
             diskDetail: diskSample.detail
+        )
+
+        metricsHistory.push(
+            cpu: cpuUsage,
+            memory: memorySample.usage,
+            disk: diskSample.usage
         )
     }
 

--- a/design/frogtray.pen
+++ b/design/frogtray.pen
@@ -6,498 +6,774 @@
       "id": "bi8Au",
       "x": 0,
       "y": 0,
-      "name": "FrogTray Tray Design",
+      "name": "FrogTray Design",
       "clip": true,
-      "width": 800,
-      "height": 2800,
+      "width": 1200,
+      "height": 1800,
       "fill": "#F5F6F8",
       "layout": "none",
       "children": [
         {
           "type": "text",
-          "id": "6hyCm",
+          "id": "GJC6D",
           "x": 60,
-          "y": 52,
-          "name": "curLabel",
+          "y": 50,
+          "name": "title",
           "fill": "#111827",
-          "content": "Current Tray UI",
+          "content": "FrogTray — 현재 구현 디자인",
           "fontFamily": "Inter",
-          "fontSize": 24,
-          "fontWeight": "600"
+          "fontSize": 28,
+          "fontWeight": "700"
         },
         {
           "type": "text",
-          "id": "i8KEb",
+          "id": "1ZK2q",
           "x": 60,
-          "y": 82,
-          "name": "curCaption",
+          "y": 86,
+          "name": "subtitle",
           "fill": "#6B7280",
-          "content": "기존 SwiftUI 메뉴바 팝오버 기준안",
+          "content": "FrogTrayApp.swift · ContentView.swift · MetricDetailView.swift 기준",
           "fontFamily": "Inter",
           "fontSize": 14,
           "fontWeight": "normal"
         },
         {
-          "type": "frame",
-          "id": "wSIDe",
+          "type": "text",
+          "id": "SCWQ2",
           "x": 60,
-          "y": 120,
-          "name": "curPanel",
-          "width": 300,
-          "fill": "#FFFFFF",
-          "cornerRadius": 16,
-          "stroke": {
-            "thickness": 1,
-            "fill": "#E5E7EB"
-          },
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#00000014",
-            "offset": {
-              "x": 0,
-              "y": 8
-            },
-            "blur": 24
-          },
-          "layout": "vertical",
-          "gap": 14,
-          "padding": 16,
+          "y": 140,
+          "name": "sec1title",
+          "fill": "#111827",
+          "content": "1. 이마 (FrogMenuBarLabel)",
+          "fontFamily": "Inter",
+          "fontSize": 22,
+          "fontWeight": "700"
+        },
+        {
+          "type": "text",
+          "id": "pmHnL",
+          "x": 60,
+          "y": 170,
+          "name": "sec1cap",
+          "fill": "#6B7280",
+          "content": "HStack(spacing:4) { FrogStatusIcon(16×14) + Text(.system(11, semibold, rounded)) }  ·  4단계 배부름 상태",
+          "fontFamily": "Inter",
+          "fontSize": 13,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "frame",
+          "id": "2Sod1",
+          "x": 60,
+          "y": 200,
+          "name": "imaRow",
+          "gap": 16,
           "children": [
             {
               "type": "frame",
-              "id": "KNIwm",
-              "name": "curHeader",
-              "width": "fill_container",
-              "layout": "vertical",
-              "gap": 4,
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "ZqoIm",
-                  "name": "curHeadTop",
-                  "width": "fill_container",
-                  "gap": 8,
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "Uv92J",
-                      "name": "curHeadIcon",
-                      "fill": "#22C55E",
-                      "content": "📊",
-                      "fontFamily": "Inter",
-                      "fontSize": 18,
-                      "fontWeight": "normal"
-                    },
-                    {
-                      "type": "text",
-                      "id": "dWkUD",
-                      "name": "curHeadTitle",
-                      "fill": "#111827",
-                      "content": "FrogTray",
-                      "fontFamily": "Inter",
-                      "fontSize": 16,
-                      "fontWeight": "600"
-                    }
-                  ]
+              "id": "SYG0o",
+              "name": "imaCalm",
+              "width": 160,
+              "fill": "#FFFFFF",
+              "cornerRadius": 16,
+              "stroke": {
+                "thickness": 1,
+                "fill": "#E5E7EB"
+              },
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#00000010",
+                "offset": {
+                  "x": 0,
+                  "y": 6
                 },
+                "blur": 16
+              },
+              "layout": "vertical",
+              "gap": 10,
+              "padding": 14,
+              "children": [
                 {
                   "type": "text",
-                  "id": "zespb",
-                  "name": "curHeadSub",
-                  "fill": "#6B7280",
-                  "content": "마지막 갱신 오후 10:56:20",
+                  "id": "akrap",
+                  "name": "t1",
+                  "fill": "#43BFB0",
+                  "content": "여유 · 0-39%",
                   "fontFamily": "Inter",
-                  "fontSize": 12,
-                  "fontWeight": "normal"
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "BDaUE",
-              "name": "curCpu",
-              "width": "fill_container",
-              "layout": "vertical",
-              "gap": 6,
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "8JPst",
-                  "name": "curCpuTop",
-                  "width": "fill_container",
-                  "justifyContent": "space_between",
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "eipaZ",
-                      "name": "curCpuLabel",
-                      "fill": "#111827",
-                      "content": "CPU",
-                      "fontFamily": "Inter",
-                      "fontSize": 16,
-                      "fontWeight": "600"
-                    },
-                    {
-                      "type": "text",
-                      "id": "IPvjW",
-                      "name": "curCpuValue",
-                      "fill": "#111827",
-                      "content": "32%",
-                      "fontFamily": "Inter",
-                      "fontSize": 15,
-                      "fontWeight": "600"
-                    }
-                  ]
+                  "fontSize": 14,
+                  "fontWeight": "700"
                 },
                 {
                   "type": "frame",
-                  "id": "Qaqfx",
-                  "name": "curCpuGauge",
+                  "id": "qMrDI",
+                  "name": "hero",
                   "width": "fill_container",
-                  "height": 6,
-                  "fill": "#E5E7EB",
-                  "cornerRadius": 999,
+                  "height": 72,
+                  "fill": "#ECFDF5",
+                  "cornerRadius": 12,
+                  "layout": "none",
                   "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "n4xf5",
+                      "x": 18,
+                      "y": 6,
+                      "name": "e1L",
+                      "fill": "#2D6A5A",
+                      "width": 14,
+                      "height": 14
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "fmpCm",
+                      "x": 40,
+                      "y": 6,
+                      "name": "e1R",
+                      "fill": "#2D6A5A",
+                      "width": 14,
+                      "height": 14
+                    },
                     {
                       "type": "rectangle",
-                      "cornerRadius": 999,
-                      "id": "VIERR",
-                      "name": "curCpuGaugeFill",
-                      "fill": "#3B82F6",
-                      "width": 86,
-                      "height": "fill_container"
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "id": "Pf0n0",
-                  "name": "curCpuDetail",
-                  "fill": "#6B7280",
-                  "content": "전체 CPU 사용률",
-                  "fontFamily": "Inter",
-                  "fontSize": 12,
-                  "fontWeight": "normal"
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "7gVWo",
-              "name": "curMem",
-              "width": "fill_container",
-              "layout": "vertical",
-              "gap": 6,
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "7BYiM",
-                  "name": "curMemTop",
-                  "width": "fill_container",
-                  "justifyContent": "space_between",
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "eTpoO",
-                      "name": "curMemLabel",
-                      "fill": "#111827",
-                      "content": "Memory",
-                      "fontFamily": "Inter",
-                      "fontSize": 16,
-                      "fontWeight": "600"
+                      "cornerRadius": 14,
+                      "id": "kscvw",
+                      "x": 16,
+                      "y": 18,
+                      "name": "b1",
+                      "fill": "#2D6A5A",
+                      "width": 40,
+                      "height": 28
                     },
                     {
-                      "type": "text",
-                      "id": "bvcVV",
-                      "name": "curMemValue",
-                      "fill": "#111827",
-                      "content": "67%",
-                      "fontFamily": "Inter",
-                      "fontSize": 15,
-                      "fontWeight": "600"
+                      "type": "ellipse",
+                      "id": "wiEyf",
+                      "x": 32,
+                      "y": 36,
+                      "name": "bl1",
+                      "fill": "#43BFB0",
+                      "width": 16,
+                      "height": 10
                     }
                   ]
                 },
                 {
                   "type": "frame",
-                  "id": "ucEh2",
-                  "name": "curMemGauge",
+                  "id": "oEwsu",
+                  "name": "menubar",
                   "width": "fill_container",
-                  "height": 6,
-                  "fill": "#E5E7EB",
-                  "cornerRadius": 999,
-                  "children": [
-                    {
-                      "type": "rectangle",
-                      "cornerRadius": 999,
-                      "id": "ESmEG",
-                      "name": "curMemGaugeFill",
-                      "fill": "#3B82F6",
-                      "width": 181,
-                      "height": "fill_container"
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "id": "RkZ28",
-                  "name": "curMemDetail",
-                  "fill": "#6B7280",
-                  "content": "11.2 GB / 16 GB",
-                  "fontFamily": "Inter",
-                  "fontSize": 12,
-                  "fontWeight": "normal"
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "6DE8A",
-              "name": "curDisk",
-              "width": "fill_container",
-              "layout": "vertical",
-              "gap": 6,
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "T5CMN",
-                  "name": "curDiskTop",
-                  "width": "fill_container",
-                  "justifyContent": "space_between",
+                  "height": 28,
+                  "fill": "#1F2937",
+                  "cornerRadius": 6,
+                  "gap": 4,
+                  "justifyContent": "center",
                   "alignItems": "center",
                   "children": [
-                    {
-                      "type": "text",
-                      "id": "5JXZr",
-                      "name": "curDiskLabel",
-                      "fill": "#111827",
-                      "content": "Disk",
-                      "fontFamily": "Inter",
-                      "fontSize": 16,
-                      "fontWeight": "600"
-                    },
-                    {
-                      "type": "text",
-                      "id": "uuPbO",
-                      "name": "curDiskValue",
-                      "fill": "#111827",
-                      "content": "74%",
-                      "fontFamily": "Inter",
-                      "fontSize": 15,
-                      "fontWeight": "600"
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "Ovflf",
-                  "name": "curDiskGauge",
-                  "width": "fill_container",
-                  "height": 6,
-                  "fill": "#E5E7EB",
-                  "cornerRadius": 999,
-                  "children": [
-                    {
-                      "type": "rectangle",
-                      "cornerRadius": 999,
-                      "id": "qvc96",
-                      "name": "curDiskGaugeFill",
-                      "fill": "#3B82F6",
-                      "width": 200,
-                      "height": "fill_container"
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "id": "hsNxm",
-                  "name": "curDiskDetail",
-                  "fill": "#6B7280",
-                  "content": "374 GB / 500 GB",
-                  "fontFamily": "Inter",
-                  "fontSize": 12,
-                  "fontWeight": "normal"
-                }
-              ]
-            },
-            {
-              "type": "rectangle",
-              "id": "vQmP9",
-              "name": "curDiv1",
-              "fill": "#E5E7EB",
-              "width": "fill_container",
-              "height": 1
-            },
-            {
-              "type": "frame",
-              "id": "rGkAs",
-              "name": "curSettings",
-              "width": "fill_container",
-              "layout": "vertical",
-              "gap": 8,
-              "children": [
-                {
-                  "type": "text",
-                  "id": "uOMBF",
-                  "name": "curSettingsTitle",
-                  "fill": "#111827",
-                  "content": "설정",
-                  "fontFamily": "Inter",
-                  "fontSize": 16,
-                  "fontWeight": "600"
-                },
-                {
-                  "type": "frame",
-                  "id": "OxCTI",
-                  "name": "curToggleRow",
-                  "width": "fill_container",
-                  "justifyContent": "space_between",
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "yuvnI",
-                      "name": "curToggleLabel",
-                      "fill": "#111827",
-                      "content": "로그인 시 자동 실행",
-                      "fontFamily": "Inter",
-                      "fontSize": 13,
-                      "fontWeight": "normal"
-                    },
                     {
                       "type": "frame",
-                      "id": "d4TQx",
-                      "name": "curToggleTrack",
-                      "width": 34,
-                      "height": 20,
-                      "fill": "#22C55E",
-                      "cornerRadius": 999,
-                      "padding": 2,
-                      "justifyContent": "end",
-                      "alignItems": "center",
+                      "id": "g2FTj",
+                      "name": "fi1",
+                      "width": 14,
+                      "height": 12,
+                      "layout": "none",
                       "children": [
                         {
                           "type": "ellipse",
-                          "id": "LwFsj",
-                          "name": "curToggleKnob",
-                          "fill": "#FFFFFF",
-                          "width": 16,
-                          "height": 16
+                          "id": "zMxGm",
+                          "x": 1,
+                          "y": 0,
+                          "name": "fi1eL",
+                          "fill": "#D1D5DB",
+                          "width": 3,
+                          "height": 3
+                        },
+                        {
+                          "type": "ellipse",
+                          "id": "xRqDK",
+                          "x": 8,
+                          "y": 0,
+                          "name": "fi1eR",
+                          "fill": "#D1D5DB",
+                          "width": 3,
+                          "height": 3
+                        },
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 3,
+                          "id": "SSV52",
+                          "x": 2,
+                          "y": 3,
+                          "name": "fi1b",
+                          "fill": "#D1D5DB",
+                          "width": 9,
+                          "height": 6
+                        },
+                        {
+                          "type": "ellipse",
+                          "id": "qpfb3",
+                          "x": 6,
+                          "y": 6,
+                          "name": "fi1bl",
+                          "fill": "#43BFB0",
+                          "width": 4,
+                          "height": 3
                         }
                       ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "z7TCc",
+                      "name": "tx1",
+                      "fill": "#D1D5DB",
+                      "content": "C24 M19 D12",
+                      "fontFamily": "Inter",
+                      "fontSize": 9,
+                      "fontWeight": "600"
                     }
                   ]
                 },
                 {
                   "type": "text",
-                  "id": "X91WP",
-                  "name": "curSettingsStatus",
+                  "id": "wabM8",
+                  "name": "n1",
                   "fill": "#6B7280",
                   "textGrowth": "fixed-width",
                   "width": "fill_container",
-                  "content": "시스템 설정 > 일반 > 로그인 항목에서 FrogTray를 허용해야 자동 실행됩니다.",
+                  "content": "배 거의 납작 · belly 5×3.5",
                   "fontFamily": "Inter",
-                  "fontSize": 12,
+                  "fontSize": 11,
                   "fontWeight": "normal"
-                },
-                {
-                  "type": "frame",
-                  "id": "xkSMd",
-                  "name": "curSettingsLinkWrap",
-                  "padding": [
-                    8,
-                    0,
-                    0,
-                    0
-                  ],
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "yKAv5",
-                      "name": "curSettingsLink",
-                      "fill": "#2563EB",
-                      "content": "시스템 설정 열기",
-                      "fontFamily": "Inter",
-                      "fontSize": 12,
-                      "fontWeight": "500"
-                    }
-                  ]
                 }
               ]
             },
             {
-              "type": "rectangle",
-              "id": "96ROd",
-              "name": "curDiv2",
-              "fill": "#E5E7EB",
-              "width": "fill_container",
-              "height": 1
-            },
-            {
               "type": "frame",
-              "id": "bsMWM",
-              "name": "curActions",
-              "width": "fill_container",
-              "justifyContent": "space_between",
-              "alignItems": "center",
+              "id": "yJb1q",
+              "name": "imaNormal",
+              "width": 160,
+              "fill": "#FFFFFF",
+              "cornerRadius": 16,
+              "stroke": {
+                "thickness": 1,
+                "fill": "#E5E7EB"
+              },
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#00000010",
+                "offset": {
+                  "x": 0,
+                  "y": 6
+                },
+                "blur": 16
+              },
+              "layout": "vertical",
+              "gap": 10,
+              "padding": 14,
               "children": [
                 {
+                  "type": "text",
+                  "id": "SuwJN",
+                  "name": "t2",
+                  "fill": "#D97741",
+                  "content": "보통 · 40-64%",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "700"
+                },
+                {
                   "type": "frame",
-                  "id": "NxFax",
-                  "name": "curRefreshBtn",
-                  "fill": "#F3F4F6",
-                  "cornerRadius": 10,
-                  "stroke": {
-                    "thickness": 1,
-                    "fill": "#E5E7EB"
-                  },
-                  "padding": [
-                    7,
-                    12
-                  ],
+                  "id": "WFPIM",
+                  "name": "hero",
+                  "width": "fill_container",
+                  "height": 72,
+                  "fill": "#FFF7ED",
+                  "cornerRadius": 12,
+                  "layout": "none",
                   "children": [
                     {
-                      "type": "text",
-                      "id": "e61E0",
-                      "name": "curRefreshTxt",
-                      "fill": "#111827",
-                      "content": "새로고침",
-                      "fontFamily": "Inter",
-                      "fontSize": 13,
-                      "fontWeight": "500"
+                      "type": "ellipse",
+                      "id": "5x11G",
+                      "x": 18,
+                      "y": 6,
+                      "name": "e2L",
+                      "fill": "#8B5C2A",
+                      "width": 14,
+                      "height": 14
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "0zu6k",
+                      "x": 40,
+                      "y": 6,
+                      "name": "e2R",
+                      "fill": "#8B5C2A",
+                      "width": 14,
+                      "height": 14
+                    },
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 14,
+                      "id": "uJrRQ",
+                      "x": 16,
+                      "y": 18,
+                      "name": "b2",
+                      "fill": "#8B5C2A",
+                      "width": 40,
+                      "height": 28
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "1GyEV",
+                      "x": 28,
+                      "y": 32,
+                      "name": "bl2",
+                      "fill": "#D97741",
+                      "width": 22,
+                      "height": 16
                     }
                   ]
                 },
                 {
                   "type": "frame",
-                  "id": "tHE8F",
-                  "name": "curQuitBtn",
-                  "fill": "#F3F4F6",
-                  "cornerRadius": 10,
-                  "stroke": {
-                    "thickness": 1,
-                    "fill": "#E5E7EB"
-                  },
-                  "padding": [
-                    7,
-                    12
-                  ],
+                  "id": "oQIBR",
+                  "name": "menubar",
+                  "width": "fill_container",
+                  "height": 28,
+                  "fill": "#1F2937",
+                  "cornerRadius": 6,
+                  "gap": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
                   "children": [
                     {
+                      "type": "frame",
+                      "id": "2wADy",
+                      "name": "fi2",
+                      "width": 14,
+                      "height": 12,
+                      "layout": "none",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "YjhXa",
+                          "x": 1,
+                          "y": 0,
+                          "name": "fi2eL",
+                          "fill": "#D1D5DB",
+                          "width": 3,
+                          "height": 3
+                        },
+                        {
+                          "type": "ellipse",
+                          "id": "8jKmB",
+                          "x": 8,
+                          "y": 0,
+                          "name": "fi2eR",
+                          "fill": "#D1D5DB",
+                          "width": 3,
+                          "height": 3
+                        },
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 3,
+                          "id": "5lGcG",
+                          "x": 2,
+                          "y": 3,
+                          "name": "fi2b",
+                          "fill": "#D1D5DB",
+                          "width": 9,
+                          "height": 6
+                        },
+                        {
+                          "type": "ellipse",
+                          "id": "N9Apc",
+                          "x": 6,
+                          "y": 5,
+                          "name": "fi2bl",
+                          "fill": "#D97741",
+                          "width": 5,
+                          "height": 4
+                        }
+                      ]
+                    },
+                    {
                       "type": "text",
-                      "id": "4ACvE",
-                      "name": "curQuitTxt",
-                      "fill": "#111827",
-                      "content": "종료",
+                      "id": "3zIzJ",
+                      "name": "tx2",
+                      "fill": "#D1D5DB",
+                      "content": "C43 M58 D37",
                       "fontFamily": "Inter",
-                      "fontSize": 13,
-                      "fontWeight": "500"
+                      "fontSize": 9,
+                      "fontWeight": "600"
                     }
                   ]
+                },
+                {
+                  "type": "text",
+                  "id": "m99Bs",
+                  "name": "n2",
+                  "fill": "#6B7280",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "배 살짝 도드라짐 · belly 6.5×5",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Vlqer",
+              "name": "imaWarning",
+              "width": 160,
+              "fill": "#FFFFFF",
+              "cornerRadius": 16,
+              "stroke": {
+                "thickness": 1,
+                "fill": "#E5E7EB"
+              },
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#00000010",
+                "offset": {
+                  "x": 0,
+                  "y": 6
+                },
+                "blur": 16
+              },
+              "layout": "vertical",
+              "gap": 10,
+              "padding": 14,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "BbhFW",
+                  "name": "t3",
+                  "fill": "#E65C5C",
+                  "content": "주의 · 65-84%",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "frame",
+                  "id": "1IXmB",
+                  "name": "hero",
+                  "width": "fill_container",
+                  "height": 72,
+                  "fill": "#FEF2F2",
+                  "cornerRadius": 12,
+                  "layout": "none",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "sopkF",
+                      "x": 18,
+                      "y": 6,
+                      "name": "e3L",
+                      "fill": "#9B3030",
+                      "width": 14,
+                      "height": 14
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "vgtJL",
+                      "x": 40,
+                      "y": 6,
+                      "name": "e3R",
+                      "fill": "#9B3030",
+                      "width": 14,
+                      "height": 14
+                    },
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 14,
+                      "id": "C6Y3N",
+                      "x": 16,
+                      "y": 18,
+                      "name": "b3",
+                      "fill": "#9B3030",
+                      "width": 40,
+                      "height": 28
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "4hURh",
+                      "x": 25,
+                      "y": 28,
+                      "name": "bl3",
+                      "fill": "#E65C5C",
+                      "width": 28,
+                      "height": 22
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "MAt6u",
+                  "name": "menubar",
+                  "width": "fill_container",
+                  "height": 28,
+                  "fill": "#1F2937",
+                  "cornerRadius": 6,
+                  "gap": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ThIT9",
+                      "name": "fi3",
+                      "width": 14,
+                      "height": 12,
+                      "layout": "none",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "TJQA2",
+                          "x": 1,
+                          "y": 0,
+                          "name": "fi3eL",
+                          "fill": "#D1D5DB",
+                          "width": 3,
+                          "height": 3
+                        },
+                        {
+                          "type": "ellipse",
+                          "id": "bTopm",
+                          "x": 8,
+                          "y": 0,
+                          "name": "fi3eR",
+                          "fill": "#D1D5DB",
+                          "width": 3,
+                          "height": 3
+                        },
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 3,
+                          "id": "NxpR9",
+                          "x": 2,
+                          "y": 3,
+                          "name": "fi3b",
+                          "fill": "#D1D5DB",
+                          "width": 9,
+                          "height": 6
+                        },
+                        {
+                          "type": "ellipse",
+                          "id": "PrH08",
+                          "x": 5,
+                          "y": 4,
+                          "name": "fi3bl",
+                          "fill": "#E65C5C",
+                          "width": 7,
+                          "height": 5
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "qKlxU",
+                      "name": "tx3",
+                      "fill": "#D1D5DB",
+                      "content": "C61 M74 D69",
+                      "fontFamily": "Inter",
+                      "fontSize": 9,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "8Yb1x",
+                  "name": "n3",
+                  "fill": "#6B7280",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "배 확실히 빵빵 · belly 8×6.5",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "vEvX3",
+              "name": "imaCritical",
+              "width": 160,
+              "fill": "#FFFFFF",
+              "cornerRadius": 16,
+              "stroke": {
+                "thickness": 1,
+                "fill": "#E5E7EB"
+              },
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#00000010",
+                "offset": {
+                  "x": 0,
+                  "y": 6
+                },
+                "blur": 16
+              },
+              "layout": "vertical",
+              "gap": 10,
+              "padding": 14,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "oAKeN",
+                  "name": "t4",
+                  "fill": "#B91C1C",
+                  "content": "위험 · 85%+",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "frame",
+                  "id": "cT93A",
+                  "name": "hero",
+                  "width": "fill_container",
+                  "height": 72,
+                  "fill": "#FEE2E2",
+                  "cornerRadius": 12,
+                  "layout": "none",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "8iGCq",
+                      "x": 18,
+                      "y": 6,
+                      "name": "e4L",
+                      "fill": "#7F1D1D",
+                      "width": 14,
+                      "height": 14
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "PxTvj",
+                      "x": 40,
+                      "y": 6,
+                      "name": "e4R",
+                      "fill": "#7F1D1D",
+                      "width": 14,
+                      "height": 14
+                    },
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 14,
+                      "id": "Oh0E1",
+                      "x": 16,
+                      "y": 18,
+                      "name": "b4",
+                      "fill": "#7F1D1D",
+                      "width": 40,
+                      "height": 28
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "65UIz",
+                      "x": 22,
+                      "y": 24,
+                      "name": "bl4",
+                      "fill": "#EF4444",
+                      "width": 34,
+                      "height": 28
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "m3jlN",
+                  "name": "menubar",
+                  "width": "fill_container",
+                  "height": 28,
+                  "fill": "#1F2937",
+                  "cornerRadius": 6,
+                  "gap": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "qbTvS",
+                      "name": "fi4",
+                      "width": 14,
+                      "height": 12,
+                      "layout": "none",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "F3xbY",
+                          "x": 1,
+                          "y": 0,
+                          "name": "fi4eL",
+                          "fill": "#D1D5DB",
+                          "width": 3,
+                          "height": 3
+                        },
+                        {
+                          "type": "ellipse",
+                          "id": "jBFbE",
+                          "x": 8,
+                          "y": 0,
+                          "name": "fi4eR",
+                          "fill": "#D1D5DB",
+                          "width": 3,
+                          "height": 3
+                        },
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 3,
+                          "id": "5Rgo8",
+                          "x": 2,
+                          "y": 3,
+                          "name": "fi4b",
+                          "fill": "#D1D5DB",
+                          "width": 9,
+                          "height": 6
+                        },
+                        {
+                          "type": "ellipse",
+                          "id": "kkrY0",
+                          "x": 4,
+                          "y": 3,
+                          "name": "fi4bl",
+                          "fill": "#EF4444",
+                          "width": 8,
+                          "height": 7
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "CSzyo",
+                      "name": "tx4",
+                      "fill": "#D1D5DB",
+                      "content": "C88 M91 D92",
+                      "fontFamily": "Inter",
+                      "fontSize": 9,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "HxeBC",
+                  "name": "n4",
+                  "fill": "#6B7280",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "터질 듯 과장된 배 · belly 9.5×8",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
                 }
               ]
             }
@@ -505,40 +781,58 @@
         },
         {
           "type": "text",
-          "id": "PlDBh",
-          "x": 400,
-          "y": 52,
-          "name": "impLabel",
+          "id": "urlHp",
+          "x": 60,
+          "y": 510,
+          "name": "sec2t",
           "fill": "#111827",
-          "content": "Improved Tray UI",
+          "content": "2. 배 — 연못 (ContentView · mainView)",
           "fontFamily": "Inter",
-          "fontSize": 24,
-          "fontWeight": "600"
+          "fontSize": 22,
+          "fontWeight": "700"
         },
         {
           "type": "text",
-          "id": "A0DhM",
-          "x": 400,
-          "y": 82,
-          "name": "impCaption",
+          "id": "8pSft",
+          "x": 60,
+          "y": 540,
+          "name": "sec2c",
           "fill": "#6B7280",
-          "content": "정보 계층과 상태 강조를 강화한 개선안",
+          "content": "MenuBarExtra(.window) · width:340 · PondTheme · glassmorphic TrayCard",
           "fontFamily": "Inter",
-          "fontSize": 14,
+          "fontSize": 13,
           "fontWeight": "normal"
         },
         {
           "type": "frame",
-          "id": "4AYma",
-          "x": 400,
-          "y": 120,
-          "name": "impPanel",
-          "width": 320,
-          "fill": "#FFFFFF",
+          "id": "ncRNB",
+          "x": 60,
+          "y": 580,
+          "name": "trayPanel",
+          "width": 340,
+          "fill": {
+            "type": "gradient",
+            "gradientType": "linear",
+            "enabled": true,
+            "rotation": 0,
+            "size": {
+              "height": 1
+            },
+            "colors": [
+              {
+                "color": "#22403D10",
+                "position": 0
+              },
+              {
+                "color": "#FFFFFF00",
+                "position": 1
+              }
+            ]
+          },
           "cornerRadius": 20,
           "stroke": {
             "thickness": 1,
-            "fill": "#E5E7EB"
+            "fill": "#5B8C5B26"
           },
           "effect": {
             "type": "shadow",
@@ -556,2689 +850,1191 @@
           "children": [
             {
               "type": "frame",
-              "id": "NaDXR",
-              "name": "impSummary",
+              "id": "e6gcG",
+              "name": "summaryCard",
               "width": "fill_container",
-              "fill": "#FFF7ED",
+              "fill": "#F8FAFB",
               "cornerRadius": 18,
+              "stroke": {
+                "thickness": 1,
+                "fill": "#5B8C5B26"
+              },
               "layout": "vertical",
-              "gap": 10,
+              "gap": 14,
               "padding": 14,
               "children": [
                 {
                   "type": "frame",
-                  "id": "Q6dYb",
-                  "name": "impSummaryTop",
+                  "id": "cASeO",
+                  "name": "sumTop",
                   "width": "fill_container",
-                  "justifyContent": "space_between",
                   "alignItems": "center",
                   "children": [
                     {
+                      "type": "frame",
+                      "id": "4EkXH",
+                      "name": "frogIco",
+                      "width": 20,
+                      "height": 17,
+                      "layout": "none",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "l8Dik",
+                          "x": 2,
+                          "y": 0,
+                          "name": "fiEyeL",
+                          "fill": "#5B8C5B",
+                          "width": 5,
+                          "height": 5
+                        },
+                        {
+                          "type": "ellipse",
+                          "id": "3VGhe",
+                          "x": 12,
+                          "y": 0,
+                          "name": "fiEyeR",
+                          "fill": "#5B8C5B",
+                          "width": 5,
+                          "height": 5
+                        },
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 5,
+                          "id": "B6CQW",
+                          "x": 3,
+                          "y": 4,
+                          "name": "fiBody",
+                          "fill": "#5B8C5B",
+                          "width": 13,
+                          "height": 10
+                        },
+                        {
+                          "type": "ellipse",
+                          "id": "L2yH1",
+                          "x": 8,
+                          "y": 8,
+                          "name": "fiBelly",
+                          "fill": "#74A695",
+                          "width": 7,
+                          "height": 5
+                        }
+                      ]
+                    },
+                    {
                       "type": "text",
-                      "id": "xmx7R",
-                      "name": "impSummaryTitle",
+                      "id": "hThP6",
+                      "name": "sumTitle",
                       "fill": "#111827",
-                      "content": "🐸 FrogTray",
+                      "content": " 개구리 연못",
                       "fontFamily": "Inter",
                       "fontSize": 16,
                       "fontWeight": "600"
                     },
                     {
                       "type": "frame",
-                      "id": "dNeSX",
-                      "name": "impSummaryBadge",
-                      "fill": "#FED7AA",
-                      "cornerRadius": 999,
-                      "padding": [
-                        5,
-                        10
-                      ],
+                      "id": "hKgCV",
+                      "name": "sumSpacer",
+                      "width": "fill_container",
+                      "height": 1
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "I7agp",
+                      "name": "sumDot",
+                      "fill": "#74A695",
+                      "width": 5,
+                      "height": 5
+                    },
+                    {
+                      "type": "text",
+                      "id": "NeFfv",
+                      "name": "sumTime",
+                      "fill": "#6B7280",
+                      "content": "오후 10:56",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "U4Gm9",
+                  "name": "gaugeRow",
+                  "width": "fill_container",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "GX5vN",
+                      "name": "cpuGauge",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 5,
+                      "alignItems": "center",
                       "children": [
                         {
+                          "type": "frame",
+                          "id": "ahrsw",
+                          "name": "g1ring",
+                          "width": 48,
+                          "height": 48,
+                          "layout": "none",
+                          "children": [
+                            {
+                              "type": "ellipse",
+                              "id": "M9Lvh",
+                              "x": 0,
+                              "y": 0,
+                              "name": "g1bg",
+                              "fill": "#43BFB012",
+                              "width": 48,
+                              "height": 48,
+                              "stroke": {
+                                "thickness": 1.5,
+                                "fill": "#43BFB033"
+                              }
+                            },
+                            {
+                              "type": "ellipse",
+                              "id": "NXAuN",
+                              "x": 21,
+                              "y": 1,
+                              "name": "g1arc",
+                              "fill": "#43BFB0",
+                              "width": 6,
+                              "height": 6
+                            },
+                            {
+                              "type": "text",
+                              "id": "0Cf2P",
+                              "x": 16,
+                              "y": 20,
+                              "name": "g1lbl",
+                              "fill": "#111827",
+                              "content": "CPU",
+                              "fontFamily": "Inter",
+                              "fontSize": 7,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
                           "type": "text",
-                          "id": "4PQ4w",
-                          "name": "impSummaryBadgeText",
-                          "fill": "#C2410C",
-                          "content": "주의",
+                          "id": "YLRBq",
+                          "name": "g1val",
+                          "fill": "#111827",
+                          "content": "32%",
                           "fontFamily": "Inter",
-                          "fontSize": 11,
+                          "fontSize": 14,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ooF3Z",
+                          "name": "g1badge",
+                          "fill": "#43BFB0",
+                          "content": "잔잔",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "KM1Lj",
+                      "name": "memGauge",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 5,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "xIZi6",
+                          "name": "g2ring",
+                          "width": 48,
+                          "height": 48,
+                          "layout": "none",
+                          "children": [
+                            {
+                              "type": "ellipse",
+                              "id": "vy1nx",
+                              "x": 0,
+                              "y": 0,
+                              "name": "g2bg",
+                              "fill": "#D9774112",
+                              "width": 48,
+                              "height": 48,
+                              "stroke": {
+                                "thickness": 1.5,
+                                "fill": "#D9774133"
+                              }
+                            },
+                            {
+                              "type": "ellipse",
+                              "id": "9cJnT",
+                              "x": 21,
+                              "y": 1,
+                              "name": "g2arc",
+                              "fill": "#D97741",
+                              "width": 6,
+                              "height": 6
+                            },
+                            {
+                              "type": "text",
+                              "id": "Tq6fz",
+                              "x": 14,
+                              "y": 20,
+                              "name": "g2lbl",
+                              "fill": "#111827",
+                              "content": "MEM",
+                              "fontFamily": "Inter",
+                              "fontSize": 7,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "LZ8lp",
+                          "name": "g2val",
+                          "fill": "#111827",
+                          "content": "67%",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "BE1ss",
+                          "name": "g2badge",
+                          "fill": "#D97741",
+                          "content": "출렁",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "uEdlx",
+                      "name": "diskGauge",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 5,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "QvDZl",
+                          "name": "g3ring",
+                          "width": 48,
+                          "height": 48,
+                          "layout": "none",
+                          "children": [
+                            {
+                              "type": "ellipse",
+                              "id": "G9ALt",
+                              "x": 0,
+                              "y": 0,
+                              "name": "g3bg",
+                              "fill": "#D9774112",
+                              "width": 48,
+                              "height": 48,
+                              "stroke": {
+                                "thickness": 1.5,
+                                "fill": "#D9774133"
+                              }
+                            },
+                            {
+                              "type": "ellipse",
+                              "id": "vNzfH",
+                              "x": 21,
+                              "y": 1,
+                              "name": "g3arc",
+                              "fill": "#D97741",
+                              "width": 6,
+                              "height": 6
+                            },
+                            {
+                              "type": "text",
+                              "id": "L1RGe",
+                              "x": 14,
+                              "y": 20,
+                              "name": "g3lbl",
+                              "fill": "#111827",
+                              "content": "DISK",
+                              "fontFamily": "Inter",
+                              "fontSize": 7,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "kB4sm",
+                          "name": "g3val",
+                          "fill": "#111827",
+                          "content": "74%",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "53hHi",
+                          "name": "g3badge",
+                          "fill": "#D97741",
+                          "content": "출렁",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
                           "fontWeight": "600"
                         }
                       ]
                     }
                   ]
-                },
-                {
-                  "type": "text",
-                  "id": "u0nPq",
-                  "name": "impSummarySub",
-                  "fill": "#374151",
-                  "content": "Memory 사용량이 가장 높습니다.",
-                  "fontFamily": "Inter",
-                  "fontSize": 14,
-                  "fontWeight": "normal"
-                },
-                {
-                  "type": "text",
-                  "id": "fWsw9",
-                  "name": "impSummaryLine",
-                  "fill": "#111827",
-                  "content": "CPU 32% · MEM 67% · DISK 74%",
-                  "fontFamily": "Inter",
-                  "fontSize": 15,
-                  "fontWeight": "600"
-                },
-                {
-                  "type": "text",
-                  "id": "Ckhu9",
-                  "name": "impSummaryTime",
-                  "fill": "#6B7280",
-                  "content": "마지막 갱신 오후 10:56",
-                  "fontFamily": "Inter",
-                  "fontSize": 12,
-                  "fontWeight": "normal"
                 }
               ]
             },
             {
               "type": "frame",
-              "id": "P5cNh",
-              "name": "impStateHeader",
+              "id": "CIHYv",
+              "name": "cpuMetricCard",
               "width": "fill_container",
+              "fill": "#F8FAFB",
+              "cornerRadius": 18,
+              "stroke": {
+                "thickness": 1,
+                "fill": "#5B8C5B26"
+              },
               "layout": "vertical",
-              "gap": 2,
-              "children": [
-                {
-                  "type": "text",
-                  "id": "Or6bT",
-                  "name": "impStateTitle",
-                  "fill": "#111827",
-                  "content": "실시간 상태",
-                  "fontFamily": "Inter",
-                  "fontSize": 16,
-                  "fontWeight": "600"
-                },
-                {
-                  "type": "text",
-                  "id": "lrkwI",
-                  "name": "impStateSub",
-                  "fill": "#6B7280",
-                  "content": "지금 가장 중요한 시스템 지표",
-                  "fontFamily": "Inter",
-                  "fontSize": 12,
-                  "fontWeight": "normal"
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "iPUll",
-              "name": "impCpu",
-              "width": "fill_container",
-              "fill": "#F9FAFB",
-              "cornerRadius": 16,
-              "layout": "vertical",
-              "gap": 10,
-              "padding": 12,
+              "gap": 12,
+              "padding": 14,
               "children": [
                 {
                   "type": "frame",
-                  "id": "oNRPw",
-                  "name": "impCpuTop",
+                  "id": "R4VqE",
+                  "name": "cpuTop",
                   "width": "fill_container",
-                  "justifyContent": "space_between",
-                  "alignItems": "center",
+                  "gap": 12,
                   "children": [
-                    {
-                      "type": "text",
-                      "id": "QnVWd",
-                      "name": "impCpuLabel",
-                      "fill": "#111827",
-                      "content": "🖥 CPU",
-                      "fontFamily": "Inter",
-                      "fontSize": 15,
-                      "fontWeight": "600"
-                    },
-                    {
-                      "type": "text",
-                      "id": "f6ZTG",
-                      "name": "impCpuValue",
-                      "fill": "#16A34A",
-                      "content": "32%",
-                      "fontFamily": "Inter",
-                      "fontSize": 20,
-                      "fontWeight": "700"
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "gqrkL",
-                  "name": "impCpuGauge",
-                  "width": "fill_container",
-                  "height": 8,
-                  "fill": "#DCFCE7",
-                  "cornerRadius": 999,
-                  "children": [
-                    {
-                      "type": "rectangle",
-                      "cornerRadius": 999,
-                      "id": "YdFVL",
-                      "name": "impCpuGaugeFill",
-                      "fill": "#22C55E",
-                      "width": 90,
-                      "height": "fill_container"
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "id": "NDnuE",
-                  "name": "impCpuDetail",
-                  "fill": "#6B7280",
-                  "content": "현재 부하는 비교적 안정적입니다.",
-                  "fontFamily": "Inter",
-                  "fontSize": 12,
-                  "fontWeight": "normal"
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "POQcd",
-              "name": "impMem",
-              "width": "fill_container",
-              "fill": "#FFF7ED",
-              "cornerRadius": 16,
-              "layout": "vertical",
-              "gap": 10,
-              "padding": 12,
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "ONnJz",
-                  "name": "impMemTop",
-                  "width": "fill_container",
-                  "justifyContent": "space_between",
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "qUSpU",
-                      "name": "impMemLabel",
-                      "fill": "#111827",
-                      "content": "🧠 Memory",
-                      "fontFamily": "Inter",
-                      "fontSize": 15,
-                      "fontWeight": "600"
-                    },
-                    {
-                      "type": "text",
-                      "id": "P1ohN",
-                      "name": "impMemValue",
-                      "fill": "#EA580C",
-                      "content": "67%",
-                      "fontFamily": "Inter",
-                      "fontSize": 20,
-                      "fontWeight": "700"
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "ecUBy",
-                  "name": "impMemGauge",
-                  "width": "fill_container",
-                  "height": 8,
-                  "fill": "#FFEDD5",
-                  "cornerRadius": 999,
-                  "children": [
-                    {
-                      "type": "rectangle",
-                      "cornerRadius": 999,
-                      "id": "Twsg4",
-                      "name": "impMemGaugeFill",
-                      "fill": "#FB923C",
-                      "width": 190,
-                      "height": "fill_container"
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "id": "j1mwP",
-                  "name": "impMemDetail",
-                  "fill": "#6B7280",
-                  "content": "11.2 GB / 16 GB · 사용량이 높아지고 있습니다.",
-                  "fontFamily": "Inter",
-                  "fontSize": 12,
-                  "fontWeight": "normal"
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "LWDk3",
-              "name": "impDisk",
-              "width": "fill_container",
-              "fill": "#FEF2F2",
-              "cornerRadius": 16,
-              "layout": "vertical",
-              "gap": 10,
-              "padding": 12,
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "fGiOU",
-                  "name": "impDiskTop",
-                  "width": "fill_container",
-                  "justifyContent": "space_between",
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "UBw3g",
-                      "name": "impDiskLabel",
-                      "fill": "#111827",
-                      "content": "💽 Disk",
-                      "fontFamily": "Inter",
-                      "fontSize": 15,
-                      "fontWeight": "600"
-                    },
-                    {
-                      "type": "text",
-                      "id": "nyWQ0",
-                      "name": "impDiskValue",
-                      "fill": "#DC2626",
-                      "content": "74%",
-                      "fontFamily": "Inter",
-                      "fontSize": 20,
-                      "fontWeight": "700"
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "O5nd8",
-                  "name": "impDiskGauge",
-                  "width": "fill_container",
-                  "height": 8,
-                  "fill": "#FEE2E2",
-                  "cornerRadius": 999,
-                  "children": [
-                    {
-                      "type": "rectangle",
-                      "cornerRadius": 999,
-                      "id": "8tlxk",
-                      "name": "impDiskGaugeFill",
-                      "fill": "#EF4444",
-                      "width": 215,
-                      "height": "fill_container"
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "id": "ilx88",
-                  "name": "impDiskDetail",
-                  "fill": "#6B7280",
-                  "content": "374 GB / 500 GB · 빠르게 여유 공간이 줄어듭니다.",
-                  "fontFamily": "Inter",
-                  "fontSize": 12,
-                  "fontWeight": "normal"
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "be6lO",
-              "name": "impSettings",
-              "width": "fill_container",
-              "fill": "#F9FAFB",
-              "cornerRadius": 16,
-              "layout": "vertical",
-              "gap": 10,
-              "padding": 12,
-              "children": [
-                {
-                  "type": "text",
-                  "id": "gJFo4",
-                  "name": "impSettingsTitle",
-                  "fill": "#111827",
-                  "content": "설정",
-                  "fontFamily": "Inter",
-                  "fontSize": 16,
-                  "fontWeight": "600"
-                },
-                {
-                  "type": "frame",
-                  "id": "DZOyg",
-                  "name": "impToggleRow",
-                  "width": "fill_container",
-                  "justifyContent": "space_between",
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "uXdIn",
-                      "name": "impToggleLabel",
-                      "fill": "#111827",
-                      "content": "로그인 시 자동 실행",
-                      "fontFamily": "Inter",
-                      "fontSize": 13,
-                      "fontWeight": "normal"
-                    },
                     {
                       "type": "frame",
-                      "id": "pAoCl",
-                      "name": "impToggleTrack",
-                      "width": 38,
-                      "height": 22,
-                      "fill": "#22C55E",
-                      "cornerRadius": 999,
-                      "padding": 2,
-                      "justifyContent": "end",
-                      "alignItems": "center",
+                      "id": "ftYhZ",
+                      "name": "cpuIcon",
+                      "width": 36,
+                      "height": 36,
+                      "layout": "none",
                       "children": [
                         {
                           "type": "ellipse",
-                          "id": "REK6E",
-                          "name": "impToggleKnob",
-                          "fill": "#FFFFFF",
-                          "width": 18,
-                          "height": 18
+                          "id": "v8F0o",
+                          "x": 0,
+                          "y": 0,
+                          "name": "cpuIconBg",
+                          "fill": "#43BFB026",
+                          "width": 36,
+                          "height": 36
+                        },
+                        {
+                          "type": "text",
+                          "id": "J5m52",
+                          "x": 10,
+                          "y": 8,
+                          "name": "cpuIconTxt",
+                          "fill": "#43BFB0",
+                          "content": "⚙",
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "600"
                         }
                       ]
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "EU5LN",
-                  "name": "impStatusBox",
-                  "width": "fill_container",
-                  "fill": "#FFFFFF",
-                  "cornerRadius": 12,
-                  "padding": [
-                    10,
-                    12
-                  ],
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "OMq5R",
-                      "name": "impStatusText",
-                      "fill": "#6B7280",
-                      "textGrowth": "fixed-width",
-                      "width": "fill_container",
-                      "content": "시스템 설정에서 허용만 완료하면 자동 실행이 활성화됩니다.",
-                      "fontFamily": "Inter",
-                      "fontSize": 12,
-                      "fontWeight": "normal"
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "dBzE9",
-                  "name": "impSettingsBtn",
-                  "fill": "#EEF2FF",
-                  "cornerRadius": 10,
-                  "padding": [
-                    8,
-                    12
-                  ],
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "cFDZp",
-                      "name": "impSettingsBtnText",
-                      "fill": "#4338CA",
-                      "content": "시스템 설정 열기",
-                      "fontFamily": "Inter",
-                      "fontSize": 12,
-                      "fontWeight": "600"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "zT4zp",
-              "name": "impActions",
-              "width": "fill_container",
-              "justifyContent": "space_between",
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "UBh8D",
-                  "name": "impRefreshBtn",
-                  "fill": "#F3F4F6",
-                  "cornerRadius": 12,
-                  "padding": [
-                    8,
-                    12
-                  ],
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "IoIfC",
-                      "name": "impRefreshTxt",
-                      "fill": "#111827",
-                      "content": "↻ 새로고침",
-                      "fontFamily": "Inter",
-                      "fontSize": 13,
-                      "fontWeight": "600"
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "CyWoV",
-                  "name": "impQuitBtn",
-                  "fill": "#FEE2E2",
-                  "cornerRadius": 12,
-                  "padding": [
-                    8,
-                    12
-                  ],
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "teNcv",
-                      "name": "impQuitTxt",
-                      "fill": "#B91C1C",
-                      "content": "⏻ 종료",
-                      "fontFamily": "Inter",
-                      "fontSize": 13,
-                      "fontWeight": "600"
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "text",
-          "id": "cAk2M",
-          "x": 60,
-          "y": 980,
-          "name": "menuTitle",
-          "fill": "#111827",
-          "content": "Menu Bar Design",
-          "fontFamily": "Inter",
-          "fontSize": 24,
-          "fontWeight": "600"
-        },
-        {
-          "type": "text",
-          "id": "UnSWF",
-          "x": 60,
-          "y": 1010,
-          "name": "menuCaption",
-          "fill": "#6B7280",
-          "content": "메뉴바에 노출되는 현재안과 개선안 비교",
-          "fontFamily": "Inter",
-          "fontSize": 14,
-          "fontWeight": "normal"
-        },
-        {
-          "type": "text",
-          "id": "I2udL",
-          "x": 60,
-          "y": 1050,
-          "name": "curMenuLabel",
-          "fill": "#111827",
-          "content": "Current Menu Bar",
-          "fontFamily": "Inter",
-          "fontSize": 18,
-          "fontWeight": "600"
-        },
-        {
-          "type": "text",
-          "id": "lzN4p",
-          "x": 400,
-          "y": 1050,
-          "name": "impMenuLabel",
-          "fill": "#111827",
-          "content": "Improved Menu Bar",
-          "fontFamily": "Inter",
-          "fontSize": 18,
-          "fontWeight": "600"
-        },
-        {
-          "type": "frame",
-          "id": "pjpLM",
-          "x": 60,
-          "y": 1088,
-          "name": "curMenuPreview",
-          "width": 300,
-          "fill": "#FFFFFF",
-          "cornerRadius": 18,
-          "stroke": {
-            "thickness": 1,
-            "fill": "#E5E7EB"
-          },
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#00000014",
-            "offset": {
-              "x": 0,
-              "y": 8
-            },
-            "blur": 24
-          },
-          "layout": "vertical",
-          "gap": 14,
-          "padding": 16,
-          "children": [
-            {
-              "type": "text",
-              "id": "wYD6u",
-              "name": "curMenuCaption",
-              "fill": "#6B7280",
-              "content": "현재 코드의 텍스트 나열형 메뉴바",
-              "fontFamily": "Inter",
-              "fontSize": 13,
-              "fontWeight": "normal"
-            },
-            {
-              "type": "frame",
-              "id": "SZmat",
-              "name": "curMenuBar",
-              "width": "fill_container",
-              "height": 42,
-              "fill": "#111827",
-              "cornerRadius": 12,
-              "padding": [
-                0,
-                12
-              ],
-              "justifyContent": "space_between",
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "text",
-                  "id": "ASJJ8",
-                  "name": "curMenuBarLeft",
-                  "fill": "#9CA3AF",
-                  "content": "  Finder  파일  편집",
-                  "fontFamily": "Inter",
-                  "fontSize": 12,
-                  "fontWeight": "normal"
-                },
-                {
-                  "type": "frame",
-                  "id": "oAW2m",
-                  "name": "curMenuItem",
-                  "fill": "#1F2937",
-                  "cornerRadius": 10,
-                  "padding": [
-                    6,
-                    10
-                  ],
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "0FIyJ",
-                      "name": "curMenuItemText",
-                      "fill": "#F9FAFB",
-                      "content": "C32% M67% D74%",
-                      "fontFamily": "Inter",
-                      "fontSize": 12,
-                      "fontWeight": "600"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "text",
-              "id": "d5Hgk",
-              "name": "curMenuNote",
-              "fill": "#6B7280",
-              "textGrowth": "fixed-width",
-              "width": "fill_container",
-              "content": "모든 지표를 같은 방식으로 나열해 길고, 한눈에 위험 신호를 파악하기 어렵습니다.",
-              "fontFamily": "Inter",
-              "fontSize": 12,
-              "fontWeight": "normal"
-            }
-          ]
-        },
-        {
-          "type": "frame",
-          "id": "Mujuh",
-          "x": 400,
-          "y": 1088,
-          "name": "impMenuPreview",
-          "width": 320,
-          "fill": "#FFFFFF",
-          "cornerRadius": 18,
-          "stroke": {
-            "thickness": 1,
-            "fill": "#E5E7EB"
-          },
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#00000014",
-            "offset": {
-              "x": 0,
-              "y": 8
-            },
-            "blur": 24
-          },
-          "layout": "vertical",
-          "gap": 14,
-          "padding": 16,
-          "children": [
-            {
-              "type": "text",
-              "id": "1dc8a",
-              "name": "impMenuCaption",
-              "fill": "#6B7280",
-              "content": "실제 구현안: frog status + always-on C/M/D triplet",
-              "fontFamily": "Inter",
-              "fontSize": 13,
-              "fontWeight": "normal"
-            },
-            {
-              "type": "frame",
-              "id": "KurNt",
-              "name": "impMenuBar",
-              "width": "fill_container",
-              "height": 42,
-              "fill": "#111827",
-              "cornerRadius": 12,
-              "padding": [
-                0,
-                12
-              ],
-              "justifyContent": "space_between",
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "text",
-                  "id": "xusgK",
-                  "name": "impMenuBarLeft",
-                  "fill": "#9CA3AF",
-                  "content": "  Finder  파일  편집",
-                  "fontFamily": "Inter",
-                  "fontSize": 12,
-                  "fontWeight": "normal"
-                },
-                {
-                  "type": "frame",
-                  "id": "Hc7cU",
-                  "name": "impMenuItem",
-                  "fill": "#11182700",
-                  "gap": 6,
-                  "padding": [
-                    6,
-                    10
-                  ],
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "YRJ44",
-                      "name": "impMenuFrog",
-                      "fill": "#F3F4F6",
-                      "content": "🐸",
-                      "fontFamily": "Inter",
-                      "fontSize": 12,
-                      "fontWeight": "normal"
-                    },
-                    {
-                      "type": "text",
-                      "id": "Kb0Zi",
-                      "name": "impMenuValue",
-                      "fill": "#F3F4F6",
-                      "content": "C32 M67 D74",
-                      "fontFamily": "Inter",
-                      "fontSize": 11,
-                      "fontWeight": "700"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "NMji6",
-              "name": "impMenuMeta",
-              "width": "fill_container",
-              "gap": 8,
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "text",
-                  "id": "6hNB5",
-                  "name": "impMeta1",
-                  "fill": "#6B7280",
-                  "content": "추천: 🐸 C32 M67 D74",
-                  "fontFamily": "Inter",
-                  "fontSize": 11,
-                  "fontWeight": "600"
-                }
-              ]
-            },
-            {
-              "type": "text",
-              "id": "1VqRj",
-              "name": "impMenuNote",
-              "fill": "#6B7280",
-              "textGrowth": "fixed-width",
-              "width": "fill_container",
-              "content": "개구리는 전체 상태(max)를 나타내고, 텍스트는 CPU/Memory/Disk를 항상 고정 순서로 보여주는 방식이 가장 명확합니다.",
-              "fontFamily": "Inter",
-              "fontSize": 12,
-              "fontWeight": "normal"
-            }
-          ]
-        },
-        {
-          "type": "text",
-          "id": "HVuM5",
-          "x": 60,
-          "y": 1288,
-          "name": "frogTitle",
-          "fill": "#111827",
-          "content": "Frog Menu Bar Concepts",
-          "fontFamily": "Inter",
-          "fontSize": 24,
-          "fontWeight": "600"
-        },
-        {
-          "type": "text",
-          "id": "4o24C",
-          "x": 60,
-          "y": 1318,
-          "name": "frogCaption",
-          "fill": "#6B7280",
-          "content": "개구리 이미지와 배의 팽창 정도로 시스템 부하를 읽는 메뉴바 시안 3종",
-          "fontFamily": "Inter",
-          "fontSize": 14,
-          "fontWeight": "normal"
-        },
-        {
-          "type": "frame",
-          "id": "olnAC",
-          "x": 60,
-          "y": 1360,
-          "name": "concept1",
-          "width": 220,
-          "fill": "#FFFFFF",
-          "cornerRadius": 18,
-          "stroke": {
-            "thickness": 1,
-            "fill": "#E5E7EB"
-          },
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#00000012",
-            "offset": {
-              "x": 0,
-              "y": 8
-            },
-            "blur": 20
-          },
-          "layout": "vertical",
-          "gap": 10,
-          "padding": 14,
-          "children": [
-            {
-              "type": "text",
-              "id": "ZGERs",
-              "name": "c1Title",
-              "fill": "#111827",
-              "content": "01. Frog + C/M/D",
-              "fontFamily": "Inter",
-              "fontSize": 16,
-              "fontWeight": "600"
-            },
-            {
-              "type": "text",
-              "id": "FDk68",
-              "name": "c1Desc",
-              "fill": "#6B7280",
-              "textGrowth": "fixed-width",
-              "width": "fill_container",
-              "content": "가장 명확한 실사용안. 개구리는 상태, 숫자는 항상 3지표 고정 노출",
-              "fontFamily": "Inter",
-              "fontSize": 12,
-              "fontWeight": "normal"
-            },
-            {
-              "type": "frame",
-              "id": "6r1eC",
-              "name": "c1Hero",
-              "width": "fill_container",
-              "height": 96,
-              "fill": {
-                "type": "image",
-                "enabled": true,
-                "url": "./images/generated-1773411211686.png",
-                "mode": "fill"
-              },
-              "cornerRadius": 16
-            },
-            {
-              "type": "frame",
-              "id": "028g2",
-              "name": "c1Menu",
-              "width": "fill_container",
-              "height": 42,
-              "fill": "#111827",
-              "cornerRadius": 12,
-              "padding": [
-                0,
-                10
-              ],
-              "justifyContent": "space_between",
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "text",
-                  "id": "Z3WKt",
-                  "name": "c1MenuLeft",
-                  "fill": "#9CA3AF",
-                  "content": " Finder",
-                  "fontFamily": "Inter",
-                  "fontSize": 11,
-                  "fontWeight": "normal"
-                },
-                {
-                  "type": "frame",
-                  "id": "X2Tnv",
-                  "name": "c1MenuItem",
-                  "gap": 6,
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "bdXox",
-                      "name": "c1Frog",
-                      "fill": "#F3F4F6",
-                      "content": "🐸",
-                      "fontFamily": "Inter",
-                      "fontSize": 13,
-                      "fontWeight": "normal"
                     },
                     {
                       "type": "frame",
-                      "id": "7yTad",
-                      "name": "c1Belly",
-                      "fill": "#11182700",
-                      "justifyContent": "center",
-                      "alignItems": "center",
+                      "id": "cQRij",
+                      "name": "cpuInfo",
+                      "layout": "vertical",
+                      "gap": 2,
                       "children": [
                         {
                           "type": "text",
-                          "id": "wrSvA",
-                          "name": "c1BellyTxt",
-                          "fill": "#F3F4F6",
-                          "content": "C32 M67 D74",
+                          "id": "PXDc5",
+                          "name": "cpuTitle",
+                          "fill": "#111827",
+                          "content": "CPU",
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Frbsx",
+                          "name": "cpuSub",
+                          "fill": "#6B7280",
+                          "content": "전체 CPU 사용률",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "2m2C0",
+                      "name": "cpuSpacer",
+                      "width": "fill_container",
+                      "height": 1
+                    },
+                    {
+                      "type": "frame",
+                      "id": "NeMS9",
+                      "name": "cpuValCol",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "alignItems": "end",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "WiN7b",
+                          "name": "cpuPct",
+                          "fill": "#111827",
+                          "content": "32%",
+                          "fontFamily": "Inter",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "mq5qE",
+                          "name": "cpuBadge",
+                          "fill": "#43BFB0",
+                          "content": "잔잔",
                           "fontFamily": "Inter",
                           "fontSize": 10,
-                          "fontWeight": "700"
+                          "fontWeight": "600"
                         }
                       ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "u2Kgy",
-              "name": "c1States",
-              "width": "fill_container",
-              "gap": 6,
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "FLOqp",
-                  "name": "c1Low",
-                  "width": 44,
-                  "fill": "#111827",
-                  "cornerRadius": 999,
-                  "padding": [
-                    5,
-                    8
-                  ],
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "eIQxR",
-                      "name": "c1LowTxt",
-                      "fill": "#F3F4F6",
-                      "content": "🐸 C22 M31 D18",
-                      "fontFamily": "Inter",
-                      "fontSize": 9,
-                      "fontWeight": "600"
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "0JqbK",
-                  "name": "c1Mid",
-                  "width": 56,
-                  "fill": "#111827",
-                  "cornerRadius": 999,
-                  "padding": [
-                    5,
-                    8
-                  ],
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "ewMTX",
-                      "name": "c1MidTxt",
-                      "fill": "#F3F4F6",
-                      "content": "🐸 C41 M56 D38",
-                      "fontFamily": "Inter",
-                      "fontSize": 9,
-                      "fontWeight": "600"
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "R1rRZ",
-                  "name": "c1High",
-                  "width": 66,
-                  "fill": "#111827",
-                  "cornerRadius": 999,
-                  "padding": [
-                    5,
-                    8
-                  ],
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "7YrGm",
-                      "name": "c1HighTxt",
-                      "fill": "#F3F4F6",
-                      "content": "🐸 C68 M72 D84",
-                      "fontFamily": "Inter",
-                      "fontSize": 9,
-                      "fontWeight": "600"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "text",
-              "id": "Fl9Y5",
-              "name": "c1Note",
-              "fill": "#6B7280",
-              "textGrowth": "fixed-width",
-              "width": "fill_container",
-              "content": "폭은 조금 더 쓰지만, 지표 식별성은 가장 좋습니다.",
-              "fontFamily": "Inter",
-              "fontSize": 12,
-              "fontWeight": "normal"
-            }
-          ]
-        },
-        {
-          "type": "frame",
-          "id": "157sR",
-          "x": 290,
-          "y": 1360,
-          "name": "concept2",
-          "width": 220,
-          "fill": "#FFFFFF",
-          "cornerRadius": 18,
-          "stroke": {
-            "thickness": 1,
-            "fill": "#E5E7EB"
-          },
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#00000012",
-            "offset": {
-              "x": 0,
-              "y": 8
-            },
-            "blur": 20
-          },
-          "layout": "vertical",
-          "gap": 10,
-          "padding": 14,
-          "children": [
-            {
-              "type": "text",
-              "id": "gCwKD",
-              "name": "c2Title",
-              "fill": "#111827",
-              "content": "02. Frog + Compact Triplet",
-              "fontFamily": "Inter",
-              "fontSize": 16,
-              "fontWeight": "600"
-            },
-            {
-              "type": "text",
-              "id": "4VH9n",
-              "name": "c2Desc",
-              "fill": "#6B7280",
-              "textGrowth": "fixed-width",
-              "width": "fill_container",
-              "content": "구분자는 점만 쓰고, 라벨은 유지해 폭을 조금 줄이는 방식",
-              "fontFamily": "Inter",
-              "fontSize": 12,
-              "fontWeight": "normal"
-            },
-            {
-              "type": "frame",
-              "id": "YGIb0",
-              "name": "c2Hero",
-              "width": "fill_container",
-              "height": 96,
-              "fill": {
-                "type": "image",
-                "enabled": true,
-                "url": "./images/generated-1773411246517.png",
-                "mode": "fill"
-              },
-              "cornerRadius": 16
-            },
-            {
-              "type": "frame",
-              "id": "G38ia",
-              "name": "c2Menu",
-              "width": "fill_container",
-              "height": 42,
-              "fill": "#111827",
-              "cornerRadius": 12,
-              "padding": [
-                0,
-                10
-              ],
-              "justifyContent": "space_between",
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "text",
-                  "id": "cGyRv",
-                  "name": "c2MenuLeft",
-                  "fill": "#9CA3AF",
-                  "content": " Finder",
-                  "fontFamily": "Inter",
-                  "fontSize": 11,
-                  "fontWeight": "normal"
-                },
-                {
-                  "type": "frame",
-                  "id": "bWghe",
-                  "name": "c2MenuItem",
-                  "gap": 6,
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "O7a5N",
-                      "name": "c2Frog",
-                      "fill": "#F3F4F6",
-                      "content": "🐸",
-                      "fontFamily": "Inter",
-                      "fontSize": 13,
-                      "fontWeight": "normal"
                     },
                     {
                       "type": "text",
-                      "id": "pTHOr",
-                      "name": "c2Metric",
-                      "fill": "#F3F4F6",
-                      "content": "C32·M67·D74",
+                      "id": "5z5b8",
+                      "name": "cpuChev",
+                      "fill": "#9CA3AF",
+                      "content": "›",
                       "fontFamily": "Inter",
-                      "fontSize": 10,
-                      "fontWeight": "700"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "pOkCV",
-              "name": "c2States",
-              "width": "fill_container",
-              "gap": 6,
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "B0ObC",
-                  "name": "c2Low",
-                  "width": 48,
-                  "fill": "#111827",
-                  "cornerRadius": 999,
-                  "padding": [
-                    5,
-                    8
-                  ],
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "iaNMb",
-                      "name": "c2LowTxt",
-                      "fill": "#F3F4F6",
-                      "content": "🐸 C22·M31·D18",
-                      "fontFamily": "Inter",
-                      "fontSize": 8,
+                      "fontSize": 16,
                       "fontWeight": "600"
                     }
                   ]
                 },
                 {
                   "type": "frame",
-                  "id": "kpoST",
-                  "name": "c2Mid",
-                  "width": 58,
-                  "fill": "#111827",
+                  "id": "MJpz9",
+                  "name": "cpuBar",
+                  "width": "fill_container",
+                  "height": 6,
                   "cornerRadius": 999,
-                  "padding": [
-                    5,
-                    8
-                  ],
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "tZDDi",
-                      "name": "c2MidTxt",
-                      "fill": "#F3F4F6",
-                      "content": "🐸 C41·M56·D38",
-                      "fontFamily": "Inter",
-                      "fontSize": 8,
-                      "fontWeight": "600"
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "fbVqw",
-                  "name": "c2High",
-                  "width": 68,
-                  "fill": "#111827",
-                  "cornerRadius": 999,
-                  "padding": [
-                    5,
-                    8
-                  ],
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "1LdNm",
-                      "name": "c2HighTxt",
-                      "fill": "#F3F4F6",
-                      "content": "🐸 C68·M72·D84",
-                      "fontFamily": "Inter",
-                      "fontSize": 8,
-                      "fontWeight": "600"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "text",
-              "id": "dPxSo",
-              "name": "c2Note",
-              "fill": "#6B7280",
-              "textGrowth": "fixed-width",
-              "width": "fill_container",
-              "content": "1안보다 압축적이지만, 그래도 세 지표를 바로 읽을 수 있습니다.",
-              "fontFamily": "Inter",
-              "fontSize": 12,
-              "fontWeight": "normal"
-            }
-          ]
-        },
-        {
-          "type": "frame",
-          "id": "sABhQ",
-          "x": 520,
-          "y": 1360,
-          "name": "concept3",
-          "width": 220,
-          "fill": "#FFFFFF",
-          "cornerRadius": 18,
-          "stroke": {
-            "thickness": 1,
-            "fill": "#E5E7EB"
-          },
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#00000012",
-            "offset": {
-              "x": 0,
-              "y": 8
-            },
-            "blur": 20
-          },
-          "layout": "vertical",
-          "gap": 10,
-          "padding": 14,
-          "children": [
-            {
-              "type": "text",
-              "id": "hyGWL",
-              "name": "c3Title",
-              "fill": "#111827",
-              "content": "03. Frog + Highlighted Worst",
-              "fontFamily": "Inter",
-              "fontSize": 16,
-              "fontWeight": "600"
-            },
-            {
-              "type": "text",
-              "id": "EMwvs",
-              "name": "c3Desc",
-              "fill": "#6B7280",
-              "textGrowth": "fixed-width",
-              "width": "fill_container",
-              "content": "항상 세 지표를 보이되, 가장 높은 항목을 맨 앞에 재배치하는 방식",
-              "fontFamily": "Inter",
-              "fontSize": 12,
-              "fontWeight": "normal"
-            },
-            {
-              "type": "frame",
-              "id": "TSdYf",
-              "name": "c3Hero",
-              "width": "fill_container",
-              "height": 96,
-              "fill": {
-                "type": "image",
-                "enabled": true,
-                "url": "./images/generated-1773411293185.png",
-                "mode": "fill"
-              },
-              "cornerRadius": 16
-            },
-            {
-              "type": "frame",
-              "id": "rP1jz",
-              "name": "c3Menu",
-              "width": "fill_container",
-              "height": 42,
-              "fill": "#111827",
-              "cornerRadius": 12,
-              "padding": [
-                0,
-                10
-              ],
-              "justifyContent": "space_between",
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "text",
-                  "id": "33sVD",
-                  "name": "c3MenuLeft",
-                  "fill": "#9CA3AF",
-                  "content": " Finder",
-                  "fontFamily": "Inter",
-                  "fontSize": 11,
-                  "fontWeight": "normal"
-                },
-                {
-                  "type": "frame",
-                  "id": "xU0bP",
-                  "name": "c3MenuItem",
-                  "gap": 6,
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "fqZQw",
-                      "name": "c3Frog",
-                      "fill": "#F3F4F6",
-                      "content": "🐸",
-                      "fontFamily": "Inter",
-                      "fontSize": 13,
-                      "fontWeight": "normal"
-                    },
-                    {
-                      "type": "frame",
-                      "id": "42K6k",
-                      "name": "c3Orb",
-                      "fill": "#11182700",
-                      "justifyContent": "center",
-                      "alignItems": "center",
-                      "children": [
-                        {
-                          "type": "text",
-                          "id": "lP8Qm",
-                          "name": "c3OrbTxt",
-                          "fill": "#F3F4F6",
-                          "content": "D74 C32 M67",
-                          "fontFamily": "Inter",
-                          "fontSize": 11,
-                          "fontWeight": "700"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "39OuH",
-              "name": "c3States",
-              "width": "fill_container",
-              "gap": 10,
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "JimE2",
-                  "name": "c3Low",
-                  "gap": 4,
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "AbwDw",
-                      "name": "c3LowTxt",
-                      "fill": "#111827",
-                      "content": "🐸",
-                      "fontFamily": "Inter",
-                      "fontSize": 12,
-                      "fontWeight": "normal"
-                    },
-                    {
-                      "type": "ellipse",
-                      "id": "5EJlM",
-                      "name": "c3LowOrb",
-                      "fill": "#111827",
-                      "width": 10,
-                      "height": 10
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "Tj0z4",
-                  "name": "c3Mid",
-                  "gap": 4,
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "nZH5n",
-                      "name": "c3MidTxt",
-                      "fill": "#111827",
-                      "content": "🐸",
-                      "fontFamily": "Inter",
-                      "fontSize": 12,
-                      "fontWeight": "normal"
-                    },
-                    {
-                      "type": "ellipse",
-                      "id": "RypF2",
-                      "name": "c3MidOrb",
-                      "fill": "#111827",
-                      "width": 16,
-                      "height": 16
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "armKY",
-                  "name": "c3High",
-                  "gap": 4,
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "type": "text",
-                      "id": "bbmzz",
-                      "name": "c3HighTxt",
-                      "fill": "#111827",
-                      "content": "🐸",
-                      "fontFamily": "Inter",
-                      "fontSize": 12,
-                      "fontWeight": "normal"
-                    },
-                    {
-                      "type": "ellipse",
-                      "id": "JE4TB",
-                      "name": "c3HighOrb",
-                      "fill": "#111827",
-                      "width": 22,
-                      "height": 22
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "text",
-              "id": "k77PZ",
-              "name": "c3Note",
-              "fill": "#6B7280",
-              "textGrowth": "fixed-width",
-              "width": "fill_container",
-              "content": "경고성은 강하지만 순서가 바뀌어 습관적인 스캔에는 불리할 수 있습니다.",
-              "fontFamily": "Inter",
-              "fontSize": 12,
-              "fontWeight": "normal"
-            }
-          ]
-        },
-        {
-          "type": "text",
-          "id": "TeGCy",
-          "x": 60,
-          "y": 1728,
-          "name": "stateTitle",
-          "fill": "#111827",
-          "content": "Frog Belly State Map",
-          "fontFamily": "Inter",
-          "fontSize": 24,
-          "fontWeight": "600"
-        },
-        {
-          "type": "text",
-          "id": "bm61h",
-          "x": 60,
-          "y": 1758,
-          "name": "stateCaption",
-          "fill": "#6B7280",
-          "content": "실제 구현 기준: 개구리 배부름은 max(CPU, Memory, Disk), 텍스트는 C/M/D를 항상 표시합니다.",
-          "fontFamily": "Inter",
-          "fontSize": 14,
-          "fontWeight": "normal"
-        },
-        {
-          "type": "frame",
-          "id": "bfSXa",
-          "x": 60,
-          "y": 1800,
-          "name": "stateCard1",
-          "width": 150,
-          "fill": "#FFFFFF",
-          "cornerRadius": 18,
-          "stroke": {
-            "thickness": 1,
-            "fill": "#E5E7EB"
-          },
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#00000010",
-            "offset": {
-              "x": 0,
-              "y": 8
-            },
-            "blur": 18
-          },
-          "layout": "vertical",
-          "gap": 10,
-          "padding": 14,
-          "children": [
-            {
-              "type": "text",
-              "id": "mFOuj",
-              "name": "s1Title",
-              "fill": "#166534",
-              "content": "여유 · 0-39%",
-              "fontFamily": "Inter",
-              "fontSize": 15,
-              "fontWeight": "600"
-            },
-            {
-              "type": "frame",
-              "id": "71qYv",
-              "name": "s1Hero",
-              "width": "fill_container",
-              "height": 92,
-              "fill": "#F0FDF4",
-              "cornerRadius": 16,
-              "gap": 8,
-              "justifyContent": "center",
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "text",
-                  "id": "Mzb6E",
-                  "name": "s1Frog",
-                  "fill": "#166534",
-                  "content": "🐸",
-                  "fontFamily": "Inter",
-                  "fontSize": 28,
-                  "fontWeight": "normal"
-                },
-                {
-                  "type": "ellipse",
-                  "id": "uG2Dj",
-                  "name": "s1Belly",
-                  "fill": "#4ADE80",
-                  "width": 16,
-                  "height": 12
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "F8Luj",
-              "name": "s1Menu",
-              "width": "fill_container",
-              "height": 34,
-              "fill": "#111827",
-              "cornerRadius": 10,
-              "justifyContent": "center",
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "text",
-                  "id": "TmNYM",
-                  "name": "s1MenuTxt",
-                  "fill": "#F3F4F6",
-                  "content": "🐸 C24 M19 D12",
-                  "fontFamily": "Inter",
-                  "fontSize": 11,
-                  "fontWeight": "700"
-                }
-              ]
-            },
-            {
-              "type": "text",
-              "id": "sPohp",
-              "name": "s1Note",
-              "fill": "#6B7280",
-              "textGrowth": "fixed-width",
-              "width": "fill_container",
-              "content": "배가 거의 납작한 상태",
-              "fontFamily": "Inter",
-              "fontSize": 12,
-              "fontWeight": "normal"
-            }
-          ]
-        },
-        {
-          "type": "frame",
-          "id": "fPXkM",
-          "x": 230,
-          "y": 1800,
-          "name": "stateCard2",
-          "width": 150,
-          "fill": "#FFFFFF",
-          "cornerRadius": 18,
-          "stroke": {
-            "thickness": 1,
-            "fill": "#E5E7EB"
-          },
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#00000010",
-            "offset": {
-              "x": 0,
-              "y": 8
-            },
-            "blur": 18
-          },
-          "layout": "vertical",
-          "gap": 10,
-          "padding": 14,
-          "children": [
-            {
-              "type": "text",
-              "id": "n6TpK",
-              "name": "s2Title",
-              "fill": "#A16207",
-              "content": "보통 · 40-64%",
-              "fontFamily": "Inter",
-              "fontSize": 15,
-              "fontWeight": "600"
-            },
-            {
-              "type": "frame",
-              "id": "enWT8",
-              "name": "s2Hero",
-              "width": "fill_container",
-              "height": 92,
-              "fill": "#FEFCE8",
-              "cornerRadius": 16,
-              "gap": 8,
-              "justifyContent": "center",
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "text",
-                  "id": "p2k8H",
-                  "name": "s2Frog",
-                  "fill": "#3F6212",
-                  "content": "🐸",
-                  "fontFamily": "Inter",
-                  "fontSize": 28,
-                  "fontWeight": "normal"
-                },
-                {
-                  "type": "ellipse",
-                  "id": "PkdmN",
-                  "name": "s2Belly",
-                  "fill": "#FACC15",
-                  "width": 24,
-                  "height": 18
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "YZOo1",
-              "name": "s2Menu",
-              "width": "fill_container",
-              "height": 34,
-              "fill": "#111827",
-              "cornerRadius": 10,
-              "justifyContent": "center",
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "text",
-                  "id": "KHoew",
-                  "name": "s2MenuTxt",
-                  "fill": "#F3F4F6",
-                  "content": "🐸 C43 M58 D37",
-                  "fontFamily": "Inter",
-                  "fontSize": 11,
-                  "fontWeight": "700"
-                }
-              ]
-            },
-            {
-              "type": "text",
-              "id": "HqeE3",
-              "name": "s2Note",
-              "fill": "#6B7280",
-              "textGrowth": "fixed-width",
-              "width": "fill_container",
-              "content": "배가 살짝 도드라짐",
-              "fontFamily": "Inter",
-              "fontSize": 12,
-              "fontWeight": "normal"
-            }
-          ]
-        },
-        {
-          "type": "frame",
-          "id": "jZ5UA",
-          "x": 400,
-          "y": 1800,
-          "name": "stateCard3",
-          "width": 150,
-          "fill": "#FFFFFF",
-          "cornerRadius": 18,
-          "stroke": {
-            "thickness": 1,
-            "fill": "#E5E7EB"
-          },
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#00000010",
-            "offset": {
-              "x": 0,
-              "y": 8
-            },
-            "blur": 18
-          },
-          "layout": "vertical",
-          "gap": 10,
-          "padding": 14,
-          "children": [
-            {
-              "type": "text",
-              "id": "Yim5h",
-              "name": "s3Title",
-              "fill": "#C2410C",
-              "content": "주의 · 65-84%",
-              "fontFamily": "Inter",
-              "fontSize": 15,
-              "fontWeight": "600"
-            },
-            {
-              "type": "frame",
-              "id": "yq98H",
-              "name": "s3Hero",
-              "width": "fill_container",
-              "height": 92,
-              "fill": "#FFF7ED",
-              "cornerRadius": 16,
-              "gap": 8,
-              "justifyContent": "center",
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "text",
-                  "id": "FzHqp",
-                  "name": "s3Frog",
-                  "fill": "#65A30D",
-                  "content": "🐸",
-                  "fontFamily": "Inter",
-                  "fontSize": 28,
-                  "fontWeight": "normal"
-                },
-                {
-                  "type": "ellipse",
-                  "id": "QzRbV",
-                  "name": "s3Belly",
-                  "fill": "#FB923C",
-                  "width": 34,
-                  "height": 26
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "TmXzo",
-              "name": "s3Menu",
-              "width": "fill_container",
-              "height": 34,
-              "fill": "#111827",
-              "cornerRadius": 10,
-              "justifyContent": "center",
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "text",
-                  "id": "Oa4wV",
-                  "name": "s3MenuTxt",
-                  "fill": "#F3F4F6",
-                  "content": "🐸 C61 M74 D69",
-                  "fontFamily": "Inter",
-                  "fontSize": 11,
-                  "fontWeight": "700"
-                }
-              ]
-            },
-            {
-              "type": "text",
-              "id": "jeBJZ",
-              "name": "s3Note",
-              "fill": "#6B7280",
-              "textGrowth": "fixed-width",
-              "width": "fill_container",
-              "content": "배가 확실히 빵빵함",
-              "fontFamily": "Inter",
-              "fontSize": 12,
-              "fontWeight": "normal"
-            }
-          ]
-        },
-        {
-          "type": "frame",
-          "id": "tHTrm",
-          "x": 570,
-          "y": 1800,
-          "name": "stateCard4",
-          "width": 150,
-          "fill": "#FFFFFF",
-          "cornerRadius": 18,
-          "stroke": {
-            "thickness": 1,
-            "fill": "#E5E7EB"
-          },
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#00000010",
-            "offset": {
-              "x": 0,
-              "y": 8
-            },
-            "blur": 18
-          },
-          "layout": "vertical",
-          "gap": 10,
-          "padding": 14,
-          "children": [
-            {
-              "type": "text",
-              "id": "fnSid",
-              "name": "s4Title",
-              "fill": "#B91C1C",
-              "content": "위험 · 85%+",
-              "fontFamily": "Inter",
-              "fontSize": 15,
-              "fontWeight": "600"
-            },
-            {
-              "type": "frame",
-              "id": "Ig88A",
-              "name": "s4Hero",
-              "width": "fill_container",
-              "height": 92,
-              "fill": "#FEF2F2",
-              "cornerRadius": 16,
-              "gap": 8,
-              "justifyContent": "center",
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "text",
-                  "id": "w7ri8",
-                  "name": "s4Frog",
-                  "fill": "#65A30D",
-                  "content": "🐸",
-                  "fontFamily": "Inter",
-                  "fontSize": 28,
-                  "fontWeight": "normal"
-                },
-                {
-                  "type": "ellipse",
-                  "id": "80SHb",
-                  "name": "s4Belly",
-                  "fill": "#EF4444",
-                  "width": 44,
-                  "height": 34
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "PcIJM",
-              "name": "s4Menu",
-              "width": "fill_container",
-              "height": 34,
-              "fill": "#111827",
-              "cornerRadius": 10,
-              "justifyContent": "center",
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "text",
-                  "id": "KSB1Y",
-                  "name": "s4MenuTxt",
-                  "fill": "#F3F4F6",
-                  "content": "🐸 C88 M91 D92",
-                  "fontFamily": "Inter",
-                  "fontSize": 11,
-                  "fontWeight": "700"
-                }
-              ]
-            },
-            {
-              "type": "text",
-              "id": "fHXEo",
-              "name": "s4Note",
-              "fill": "#6B7280",
-              "textGrowth": "fixed-width",
-              "width": "fill_container",
-              "content": "터질 듯 과장된 배",
-              "fontFamily": "Inter",
-              "fontSize": 12,
-              "fontWeight": "normal"
-            }
-          ]
-        },
-        {
-          "type": "text",
-          "id": "nqZ5t",
-          "x": 60,
-          "y": 2300,
-          "name": "imaTitle",
-          "fill": "#111827",
-          "content": "이마 — 현재 구현 (FrogMenuBarLabel)",
-          "fontFamily": "Inter",
-          "fontSize": 24,
-          "fontWeight": "600"
-        },
-        {
-          "type": "text",
-          "id": "Kiy86",
-          "x": 60,
-          "y": 2330,
-          "name": "imaCaption",
-          "fill": "#6B7280",
-          "content": "FrogTrayApp.swift 기준 · FrogStatusIcon(눈깔) + 이마글씨 · 4단계 배부름 상태",
-          "fontFamily": "Inter",
-          "fontSize": 14,
-          "fontWeight": "normal"
-        },
-        {
-          "type": "frame",
-          "id": "H5dB5",
-          "x": 60,
-          "y": 2370,
-          "name": "imaCalm",
-          "width": 160,
-          "fill": "#FFFFFF",
-          "cornerRadius": 18,
-          "stroke": {
-            "thickness": 1,
-            "fill": "#E5E7EB"
-          },
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#00000010",
-            "offset": {
-              "x": 0,
-              "y": 8
-            },
-            "blur": 18
-          },
-          "layout": "vertical",
-          "gap": 10,
-          "padding": 14,
-          "children": [
-            {
-              "type": "text",
-              "id": "lWLpb",
-              "name": "imaCalm_title",
-              "fill": "#166534",
-              "content": "여유 · 0-39%",
-              "fontFamily": "Inter",
-              "fontSize": 15,
-              "fontWeight": "600"
-            },
-            {
-              "type": "frame",
-              "id": "adZqG",
-              "name": "imaCalm_hero",
-              "width": "fill_container",
-              "height": 80,
-              "fill": "#F0FDF4",
-              "cornerRadius": 12,
-              "layout": "none",
-              "children": [
-                {
-                  "type": "ellipse",
-                  "id": "amemX",
-                  "x": 16,
-                  "y": 4,
-                  "name": "eye",
-                  "fill": "#166534",
-                  "width": 14,
-                  "height": 14
-                },
-                {
-                  "type": "ellipse",
-                  "id": "o19M1",
-                  "x": 38,
-                  "y": 4,
-                  "name": "eye",
-                  "fill": "#166534",
-                  "width": 14,
-                  "height": 14
-                },
-                {
-                  "type": "rectangle",
-                  "cornerRadius": 14,
-                  "id": "l5jN4",
-                  "x": 13,
-                  "y": 16,
-                  "name": "body",
-                  "fill": "#166534",
-                  "width": 40,
-                  "height": 28
-                },
-                {
-                  "type": "ellipse",
-                  "id": "uu44m",
-                  "x": 30,
-                  "y": 34,
-                  "name": "belly",
-                  "fill": "#4ADE80",
-                  "width": 18,
-                  "height": 12
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "5a9pZ",
-              "name": "imaCalm_menubar",
-              "width": "fill_container",
-              "height": 30,
-              "fill": "#111827",
-              "cornerRadius": 8,
-              "gap": 4,
-              "justifyContent": "center",
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "68ggL",
-                  "name": "frogIcon",
-                  "width": 16,
-                  "height": 14,
                   "layout": "none",
                   "children": [
                     {
-                      "type": "ellipse",
-                      "id": "ACxHL",
-                      "x": 2,
+                      "type": "rectangle",
+                      "cornerRadius": 999,
+                      "id": "fdKOz",
+                      "x": 0,
                       "y": 0,
-                      "name": "fe1L",
-                      "fill": "#E5E7EB",
-                      "width": 4,
-                      "height": 4
-                    },
-                    {
-                      "type": "ellipse",
-                      "id": "az68R",
-                      "x": 10,
-                      "y": 0,
-                      "name": "fe1R",
-                      "fill": "#E5E7EB",
-                      "width": 4,
-                      "height": 4
+                      "name": "cpuBarBg",
+                      "fill": "#43BFB01F",
+                      "width": 308,
+                      "height": 6
                     },
                     {
                       "type": "rectangle",
-                      "cornerRadius": 4,
-                      "id": "qMjpT",
-                      "x": 2,
-                      "y": 4,
-                      "name": "fb1",
-                      "fill": "#E5E7EB",
-                      "width": 11,
-                      "height": 8
-                    },
-                    {
-                      "type": "ellipse",
-                      "id": "XEYQ0",
-                      "x": 7,
-                      "y": 7,
-                      "name": "fbl1",
-                      "fill": "#4ADE80",
-                      "width": 5,
-                      "height": 3
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "id": "i2Rwq",
-                  "name": "mt1",
-                  "fill": "#E5E7EB",
-                  "content": "C24 M19 D12",
-                  "fontFamily": "Inter",
-                  "fontSize": 10,
-                  "fontWeight": "600"
-                }
-              ]
-            },
-            {
-              "type": "text",
-              "id": "bvwYh",
-              "name": "imaCalm_note",
-              "fill": "#6B7280",
-              "textGrowth": "fixed-width",
-              "width": "fill_container",
-              "content": "배가 거의 납작\n눈깔 크기: 5×3.5",
-              "fontFamily": "Inter",
-              "fontSize": 11,
-              "fontWeight": "normal"
-            }
-          ]
-        },
-        {
-          "type": "frame",
-          "id": "VkVh2",
-          "x": 240,
-          "y": 2370,
-          "name": "imaNormal",
-          "width": 160,
-          "fill": "#FFFFFF",
-          "cornerRadius": 18,
-          "stroke": {
-            "thickness": 1,
-            "fill": "#E5E7EB"
-          },
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#00000010",
-            "offset": {
-              "x": 0,
-              "y": 8
-            },
-            "blur": 18
-          },
-          "layout": "vertical",
-          "gap": 10,
-          "padding": 14,
-          "children": [
-            {
-              "type": "text",
-              "id": "6P9bj",
-              "name": "imaNormal_title",
-              "fill": "#A16207",
-              "content": "보통 · 40-64%",
-              "fontFamily": "Inter",
-              "fontSize": 15,
-              "fontWeight": "600"
-            },
-            {
-              "type": "frame",
-              "id": "c2LIc",
-              "name": "imaNormal_hero",
-              "width": "fill_container",
-              "height": 80,
-              "fill": "#FEFCE8",
-              "cornerRadius": 12,
-              "layout": "none",
-              "children": [
-                {
-                  "type": "ellipse",
-                  "id": "DWWTG",
-                  "x": 16,
-                  "y": 4,
-                  "name": "eye",
-                  "fill": "#A16207",
-                  "width": 14,
-                  "height": 14
-                },
-                {
-                  "type": "ellipse",
-                  "id": "MyrdL",
-                  "x": 38,
-                  "y": 4,
-                  "name": "eye",
-                  "fill": "#A16207",
-                  "width": 14,
-                  "height": 14
-                },
-                {
-                  "type": "rectangle",
-                  "cornerRadius": 14,
-                  "id": "zGGco",
-                  "x": 13,
-                  "y": 16,
-                  "name": "body",
-                  "fill": "#A16207",
-                  "width": 40,
-                  "height": 28
-                },
-                {
-                  "type": "ellipse",
-                  "id": "6pJ7n",
-                  "x": 27,
-                  "y": 30,
-                  "name": "belly",
-                  "fill": "#FACC15",
-                  "width": 24,
-                  "height": 18
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "eZsE3",
-              "name": "imaNormal_menubar",
-              "width": "fill_container",
-              "height": 30,
-              "fill": "#111827",
-              "cornerRadius": 8,
-              "gap": 4,
-              "justifyContent": "center",
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "CY1aA",
-                  "name": "frogIcon",
-                  "width": 16,
-                  "height": 14,
-                  "layout": "none",
-                  "children": [
-                    {
-                      "type": "ellipse",
-                      "id": "8U4h8",
-                      "x": 2,
+                      "cornerRadius": 999,
+                      "id": "ZQekj",
+                      "x": 0,
                       "y": 0,
-                      "name": "fe2L",
-                      "fill": "#E5E7EB",
-                      "width": 4,
-                      "height": 4
-                    },
-                    {
-                      "type": "ellipse",
-                      "id": "8XMO5",
-                      "x": 10,
-                      "y": 0,
-                      "name": "fe2R",
-                      "fill": "#E5E7EB",
-                      "width": 4,
-                      "height": 4
-                    },
-                    {
-                      "type": "rectangle",
-                      "cornerRadius": 4,
-                      "id": "TEds3",
-                      "x": 2,
-                      "y": 4,
-                      "name": "fb2",
-                      "fill": "#E5E7EB",
-                      "width": 11,
-                      "height": 8
-                    },
-                    {
-                      "type": "ellipse",
-                      "id": "oZjHC",
-                      "x": 6,
-                      "y": 6,
-                      "name": "fbl2",
-                      "fill": "#FACC15",
-                      "width": 6,
-                      "height": 5
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "id": "UxmG7",
-                  "name": "mt2",
-                  "fill": "#E5E7EB",
-                  "content": "C43 M58 D37",
-                  "fontFamily": "Inter",
-                  "fontSize": 10,
-                  "fontWeight": "600"
-                }
-              ]
-            },
-            {
-              "type": "text",
-              "id": "sKgLb",
-              "name": "imaNormal_note",
-              "fill": "#6B7280",
-              "textGrowth": "fixed-width",
-              "width": "fill_container",
-              "content": "배가 살짝 도드라짐\n눈깔 크기: 6.5×5",
-              "fontFamily": "Inter",
-              "fontSize": 11,
-              "fontWeight": "normal"
-            }
-          ]
-        },
-        {
-          "type": "frame",
-          "id": "YIPIH",
-          "x": 420,
-          "y": 2370,
-          "name": "imaWarning",
-          "width": 160,
-          "fill": "#FFFFFF",
-          "cornerRadius": 18,
-          "stroke": {
-            "thickness": 1,
-            "fill": "#E5E7EB"
-          },
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#00000010",
-            "offset": {
-              "x": 0,
-              "y": 8
-            },
-            "blur": 18
-          },
-          "layout": "vertical",
-          "gap": 10,
-          "padding": 14,
-          "children": [
-            {
-              "type": "text",
-              "id": "8ciG9",
-              "name": "imaWarning_title",
-              "fill": "#C2410C",
-              "content": "주의 · 65-84%",
-              "fontFamily": "Inter",
-              "fontSize": 15,
-              "fontWeight": "600"
-            },
-            {
-              "type": "frame",
-              "id": "kZO9C",
-              "name": "imaWarning_hero",
-              "width": "fill_container",
-              "height": 80,
-              "fill": "#FFF7ED",
-              "cornerRadius": 12,
-              "layout": "none",
-              "children": [
-                {
-                  "type": "ellipse",
-                  "id": "lbeMP",
-                  "x": 16,
-                  "y": 4,
-                  "name": "eye",
-                  "fill": "#C2410C",
-                  "width": 14,
-                  "height": 14
-                },
-                {
-                  "type": "ellipse",
-                  "id": "CuUHs",
-                  "x": 38,
-                  "y": 4,
-                  "name": "eye",
-                  "fill": "#C2410C",
-                  "width": 14,
-                  "height": 14
-                },
-                {
-                  "type": "rectangle",
-                  "cornerRadius": 14,
-                  "id": "RWpJu",
-                  "x": 13,
-                  "y": 16,
-                  "name": "body",
-                  "fill": "#C2410C",
-                  "width": 40,
-                  "height": 28
-                },
-                {
-                  "type": "ellipse",
-                  "id": "jAsMH",
-                  "x": 24,
-                  "y": 27,
-                  "name": "belly",
-                  "fill": "#FB923C",
-                  "width": 30,
-                  "height": 24
-                }
-              ]
-            },
-            {
-              "type": "frame",
-              "id": "tGhDb",
-              "name": "imaWarning_menubar",
-              "width": "fill_container",
-              "height": 30,
-              "fill": "#111827",
-              "cornerRadius": 8,
-              "gap": 4,
-              "justifyContent": "center",
-              "alignItems": "center",
-              "children": [
-                {
-                  "type": "frame",
-                  "id": "UV6xm",
-                  "name": "frogIcon",
-                  "width": 16,
-                  "height": 14,
-                  "layout": "none",
-                  "children": [
-                    {
-                      "type": "ellipse",
-                      "id": "dCiGR",
-                      "x": 2,
-                      "y": 0,
-                      "name": "fe3L",
-                      "fill": "#E5E7EB",
-                      "width": 4,
-                      "height": 4
-                    },
-                    {
-                      "type": "ellipse",
-                      "id": "iiMOf",
-                      "x": 10,
-                      "y": 0,
-                      "name": "fe3R",
-                      "fill": "#E5E7EB",
-                      "width": 4,
-                      "height": 4
-                    },
-                    {
-                      "type": "rectangle",
-                      "cornerRadius": 4,
-                      "id": "FoyqW",
-                      "x": 2,
-                      "y": 4,
-                      "name": "fb3",
-                      "fill": "#E5E7EB",
-                      "width": 11,
-                      "height": 8
-                    },
-                    {
-                      "type": "ellipse",
-                      "id": "JwUr6",
-                      "x": 5,
-                      "y": 5,
-                      "name": "fbl3",
-                      "fill": "#FB923C",
-                      "width": 8,
+                      "name": "cpuBarFill",
+                      "fill": {
+                        "type": "gradient",
+                        "gradientType": "linear",
+                        "enabled": true,
+                        "rotation": 90,
+                        "size": {
+                          "height": 1
+                        },
+                        "colors": [
+                          {
+                            "color": "#43BFB099",
+                            "position": 0
+                          },
+                          {
+                            "color": "#43BFB0",
+                            "position": 1
+                          }
+                        ]
+                      },
+                      "width": 98,
                       "height": 6
                     }
                   ]
                 },
                 {
                   "type": "text",
-                  "id": "Ckcg3",
-                  "name": "mt3",
-                  "fill": "#E5E7EB",
-                  "content": "C61 M74 D69",
+                  "id": "tQcrf",
+                  "name": "cpuProc",
+                  "fill": "#111827",
+                  "content": "💧 가장 큰 물결  Xcode · 12.3%",
                   "fontFamily": "Inter",
-                  "fontSize": 10,
-                  "fontWeight": "600"
-                }
-              ]
-            },
-            {
-              "type": "text",
-              "id": "ffuAW",
-              "name": "imaWarning_note",
-              "fill": "#6B7280",
-              "textGrowth": "fixed-width",
-              "width": "fill_container",
-              "content": "배가 확실히 빵빵함\n눈깔 크기: 8×6.5",
-              "fontFamily": "Inter",
-              "fontSize": 11,
-              "fontWeight": "normal"
-            }
-          ]
-        },
-        {
-          "type": "frame",
-          "id": "46Q7t",
-          "x": 600,
-          "y": 2370,
-          "name": "imaCritical",
-          "width": 160,
-          "fill": "#FFFFFF",
-          "cornerRadius": 18,
-          "stroke": {
-            "thickness": 1,
-            "fill": "#E5E7EB"
-          },
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#00000010",
-            "offset": {
-              "x": 0,
-              "y": 8
-            },
-            "blur": 18
-          },
-          "layout": "vertical",
-          "gap": 10,
-          "padding": 14,
-          "children": [
-            {
-              "type": "text",
-              "id": "gz9MP",
-              "name": "imaCritical_title",
-              "fill": "#B91C1C",
-              "content": "위험 · 85%+",
-              "fontFamily": "Inter",
-              "fontSize": 15,
-              "fontWeight": "600"
-            },
-            {
-              "type": "frame",
-              "id": "YqQb5",
-              "name": "imaCritical_hero",
-              "width": "fill_container",
-              "height": 80,
-              "fill": "#FEF2F2",
-              "cornerRadius": 12,
-              "layout": "none",
-              "children": [
-                {
-                  "type": "ellipse",
-                  "id": "qmtkB",
-                  "x": 16,
-                  "y": 4,
-                  "name": "eye",
-                  "fill": "#B91C1C",
-                  "width": 14,
-                  "height": 14
+                  "fontSize": 12,
+                  "fontWeight": "normal"
                 },
                 {
-                  "type": "ellipse",
-                  "id": "g5XmN",
-                  "x": 38,
-                  "y": 4,
-                  "name": "eye",
-                  "fill": "#B91C1C",
-                  "width": 14,
-                  "height": 14
-                },
-                {
-                  "type": "rectangle",
-                  "cornerRadius": 14,
-                  "id": "jiZn5",
-                  "x": 13,
-                  "y": 16,
-                  "name": "body",
-                  "fill": "#B91C1C",
-                  "width": 40,
-                  "height": 28
-                },
-                {
-                  "type": "ellipse",
-                  "id": "8RZ40",
-                  "x": 21,
-                  "y": 24,
-                  "name": "belly",
-                  "fill": "#EF4444",
-                  "width": 36,
-                  "height": 30
+                  "type": "text",
+                  "id": "O76x1",
+                  "name": "cpuDet",
+                  "fill": "#6B7280",
+                  "content": "연못 수면이 고요합니다",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
                 }
               ]
             },
             {
               "type": "frame",
-              "id": "gIYQp",
-              "name": "imaCritical_menubar",
+              "id": "Ieu58",
+              "name": "memMetricCard",
               "width": "fill_container",
-              "height": 30,
-              "fill": "#111827",
-              "cornerRadius": 8,
-              "gap": 4,
-              "justifyContent": "center",
-              "alignItems": "center",
+              "fill": "#F8FAFB",
+              "cornerRadius": 18,
+              "stroke": {
+                "thickness": 1,
+                "fill": "#5B8C5B26"
+              },
+              "layout": "vertical",
+              "gap": 12,
+              "padding": 14,
               "children": [
                 {
                   "type": "frame",
-                  "id": "mQ1JR",
-                  "name": "frogIcon",
-                  "width": 16,
-                  "height": 14,
+                  "id": "2xDWF",
+                  "name": "memTop",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "7n1gl",
+                      "name": "memIcon",
+                      "width": 36,
+                      "height": 36,
+                      "layout": "none",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "mk3nH",
+                          "x": 0,
+                          "y": 0,
+                          "name": "memIconBg",
+                          "fill": "#D9774126",
+                          "width": 36,
+                          "height": 36
+                        },
+                        {
+                          "type": "text",
+                          "id": "pPOSO",
+                          "x": 10,
+                          "y": 8,
+                          "name": "memIconTxt",
+                          "fill": "#D97741",
+                          "content": "▦",
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "XhxSq",
+                      "name": "memInfo",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "5HCWP",
+                          "name": "memTitle",
+                          "fill": "#111827",
+                          "content": "Memory",
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "wWOW1",
+                          "name": "memSubt",
+                          "fill": "#6B7280",
+                          "content": "메모리 점유",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "32dhB",
+                      "name": "memSpc",
+                      "width": "fill_container",
+                      "height": 1
+                    },
+                    {
+                      "type": "frame",
+                      "id": "hte9i",
+                      "name": "memValC",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "alignItems": "end",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "3LOyN",
+                          "name": "memPct",
+                          "fill": "#111827",
+                          "content": "67%",
+                          "fontFamily": "Inter",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "tUkXc",
+                          "name": "memBdg",
+                          "fill": "#D97741",
+                          "content": "출렁",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "MATXp",
+                      "name": "memChv",
+                      "fill": "#9CA3AF",
+                      "content": "›",
+                      "fontFamily": "Inter",
+                      "fontSize": 16,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "mF95E",
+                  "name": "memBar",
+                  "width": "fill_container",
+                  "height": 6,
+                  "cornerRadius": 999,
                   "layout": "none",
                   "children": [
                     {
-                      "type": "ellipse",
-                      "id": "vvaoY",
-                      "x": 2,
+                      "type": "rectangle",
+                      "cornerRadius": 999,
+                      "id": "sVJJm",
+                      "x": 0,
                       "y": 0,
-                      "name": "fe4L",
-                      "fill": "#E5E7EB",
-                      "width": 4,
-                      "height": 4
-                    },
-                    {
-                      "type": "ellipse",
-                      "id": "gyDj3",
-                      "x": 10,
-                      "y": 0,
-                      "name": "fe4R",
-                      "fill": "#E5E7EB",
-                      "width": 4,
-                      "height": 4
+                      "name": "memBBg",
+                      "fill": "#D974411F",
+                      "width": 308,
+                      "height": 6
                     },
                     {
                       "type": "rectangle",
-                      "cornerRadius": 4,
-                      "id": "83UCs",
-                      "x": 2,
-                      "y": 4,
-                      "name": "fb4",
-                      "fill": "#E5E7EB",
-                      "width": 11,
-                      "height": 8
-                    },
-                    {
-                      "type": "ellipse",
-                      "id": "6R5A3",
-                      "x": 4,
-                      "y": 4,
-                      "name": "fbl4",
-                      "fill": "#EF4444",
-                      "width": 9,
-                      "height": 8
+                      "cornerRadius": 999,
+                      "id": "F7eaG",
+                      "x": 0,
+                      "y": 0,
+                      "name": "memBFl",
+                      "fill": {
+                        "type": "gradient",
+                        "gradientType": "linear",
+                        "enabled": true,
+                        "rotation": 90,
+                        "size": {
+                          "height": 1
+                        },
+                        "colors": [
+                          {
+                            "color": "#D9774199",
+                            "position": 0
+                          },
+                          {
+                            "color": "#D97741",
+                            "position": 1
+                          }
+                        ]
+                      },
+                      "width": 206,
+                      "height": 6
                     }
                   ]
                 },
                 {
                   "type": "text",
-                  "id": "rCKpP",
-                  "name": "mt4",
-                  "fill": "#E5E7EB",
-                  "content": "C88 M91 D92",
+                  "id": "gE5RO",
+                  "name": "memPrc",
+                  "fill": "#111827",
+                  "content": "💧 가장 큰 물결  Safari · 1.8 GB",
                   "fontFamily": "Inter",
-                  "fontSize": 10,
-                  "fontWeight": "600"
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "AFhOf",
+                  "name": "memDet",
+                  "fill": "#6B7280",
+                  "content": "11.2 GB / 16 GB",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
                 }
               ]
             },
             {
-              "type": "text",
-              "id": "6kF5C",
-              "name": "imaCritical_note",
-              "fill": "#6B7280",
-              "textGrowth": "fixed-width",
+              "type": "frame",
+              "id": "whkXo",
+              "name": "diskMetricCard",
               "width": "fill_container",
-              "content": "터질 듯 과장된 배\n눈깔 크기: 9.5×8",
-              "fontFamily": "Inter",
-              "fontSize": 11,
-              "fontWeight": "normal"
+              "fill": "#F8FAFB",
+              "cornerRadius": 18,
+              "stroke": {
+                "thickness": 1,
+                "fill": "#5B8C5B26"
+              },
+              "layout": "vertical",
+              "gap": 12,
+              "padding": 14,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "wINFY",
+                  "name": "dskTop",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "UBFvr",
+                      "name": "dskIcon",
+                      "width": 36,
+                      "height": 36,
+                      "layout": "none",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "iWWUM",
+                          "x": 0,
+                          "y": 0,
+                          "name": "dskIBg",
+                          "fill": "#D9774126",
+                          "width": 36,
+                          "height": 36
+                        },
+                        {
+                          "type": "text",
+                          "id": "hDbxl",
+                          "x": 10,
+                          "y": 8,
+                          "name": "dskITx",
+                          "fill": "#D97741",
+                          "content": "◻",
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ogYvw",
+                      "name": "dskInf",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "NGpER",
+                          "name": "dskTtl",
+                          "fill": "#111827",
+                          "content": "Disk",
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "r6KlN",
+                          "name": "dskSub",
+                          "fill": "#6B7280",
+                          "content": "시스템 디스크 사용량",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "IsRq4",
+                      "name": "dskSpc",
+                      "width": "fill_container",
+                      "height": 1
+                    },
+                    {
+                      "type": "frame",
+                      "id": "xPJZB",
+                      "name": "dskVC",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "alignItems": "end",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "XYu89",
+                          "name": "dskPct",
+                          "fill": "#111827",
+                          "content": "74%",
+                          "fontFamily": "Inter",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "etOAS",
+                          "name": "dskBdg",
+                          "fill": "#D97741",
+                          "content": "출렁",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "2H2Rl",
+                      "name": "dskChv",
+                      "fill": "#9CA3AF",
+                      "content": "›",
+                      "fontFamily": "Inter",
+                      "fontSize": 16,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ft2HS",
+                  "name": "dskBar",
+                  "width": "fill_container",
+                  "height": 6,
+                  "cornerRadius": 999,
+                  "layout": "none",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 999,
+                      "id": "u6Yyw",
+                      "x": 0,
+                      "y": 0,
+                      "name": "dskBBg",
+                      "fill": "#D974411F",
+                      "width": 308,
+                      "height": 6
+                    },
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 999,
+                      "id": "0vlli",
+                      "x": 0,
+                      "y": 0,
+                      "name": "dskBFl",
+                      "fill": {
+                        "type": "gradient",
+                        "gradientType": "linear",
+                        "enabled": true,
+                        "rotation": 90,
+                        "size": {
+                          "height": 1
+                        },
+                        "colors": [
+                          {
+                            "color": "#D9774199",
+                            "position": 0
+                          },
+                          {
+                            "color": "#D97741",
+                            "position": 1
+                          }
+                        ]
+                      },
+                      "width": 228,
+                      "height": 6
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "5Ri3f",
+                  "name": "dskPrc",
+                  "fill": "#111827",
+                  "content": "💧 가장 큰 물결  Spotlight · 45 MB",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "sVjYN",
+                  "name": "dskDet",
+                  "fill": "#6B7280",
+                  "content": "374 GB / 500 GB",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Vx1F5",
+              "name": "settingsCard",
+              "width": "fill_container",
+              "fill": "#F8FAFB",
+              "cornerRadius": 18,
+              "stroke": {
+                "thickness": 1,
+                "fill": "#5B8C5B26"
+              },
+              "layout": "vertical",
+              "gap": 12,
+              "padding": 14,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "UFPrk",
+                  "name": "setHdr",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "LiGQm",
+                      "name": "setDot",
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "eFOce",
+                          "name": "setDotC",
+                          "fill": "#5B8C5B",
+                          "width": 6,
+                          "height": 6
+                        },
+                        {
+                          "type": "text",
+                          "id": "aKqDw",
+                          "name": "setTtl",
+                          "fill": "#111827",
+                          "content": "연못 설정",
+                          "fontFamily": "Inter",
+                          "fontSize": 16,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "Ri570",
+                      "name": "setSub",
+                      "fill": "#6B7280",
+                      "content": "앱 동작과 로그인 시 자동 실행",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Z9ULY",
+                  "name": "togRow",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "vRDa7",
+                      "name": "togLbl",
+                      "fill": "#111827",
+                      "content": "로그인 시 자동 실행",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 12,
+                      "id": "KHUMw",
+                      "name": "togSwt",
+                      "fill": "#43BFB0",
+                      "width": 42,
+                      "height": 24
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "syj5h",
+                      "name": "togKnb",
+                      "fill": "#FFFFFF",
+                      "width": 20,
+                      "height": 20
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "0ZpRb",
+                  "name": "setMsg",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "DvGzk",
+                      "name": "setIco",
+                      "fill": "#5B8C5B",
+                      "content": "✓",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "QBVIZ",
+                      "name": "setTxt",
+                      "fill": "#5B8C5B",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "자동 실행이 설정되어 있습니다",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ylnO2",
+              "name": "actionRow",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ORJ4t",
+                  "name": "refBtn",
+                  "fill": "#F3F4F6",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#E5E7EB"
+                  },
+                  "gap": 4,
+                  "padding": [
+                    7,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "QR2jk",
+                      "name": "refIco",
+                      "fill": "#374151",
+                      "content": "↻",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "perxI",
+                      "name": "refLbl",
+                      "fill": "#374151",
+                      "content": "새로고침",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "8sHgn",
+                  "name": "quitBtn",
+                  "fill": "#E65C5C",
+                  "cornerRadius": 12,
+                  "stroke": {
+                    "thickness": 1,
+                    "fill": "#E65C5C"
+                  },
+                  "gap": 4,
+                  "padding": [
+                    7,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "efDWT",
+                      "name": "quitIco",
+                      "fill": "#FFFFFF",
+                      "content": "⏻",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Nu1gi",
+                      "name": "quitLbl",
+                      "fill": "#FFFFFF",
+                      "content": "종료",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
             }
           ]
-        },
-        {
-          "type": "text",
-          "id": "V05Ll",
-          "x": 60,
-          "y": 2360,
-          "name": "imaStructLabel",
-          "fill": "#374151",
-          "content": "이마 구조: HStack(spacing:4) { FrogStatusIcon(16×14) + Text(\"C{cpu}% M{mem}% D{disk}%\", .system(11, semibold, rounded)) }",
-          "fontFamily": "Inter",
-          "fontSize": 12,
-          "fontWeight": "500"
         }
       ]
     }

--- a/design/frogtray.pen
+++ b/design/frogtray.pen
@@ -9,7 +9,7 @@
       "name": "FrogTray Tray Design",
       "clip": true,
       "width": 800,
-      "height": 2240,
+      "height": 2800,
       "fill": "#F5F6F8",
       "layout": "none",
       "children": [
@@ -2487,6 +2487,758 @@
               "fontWeight": "normal"
             }
           ]
+        },
+        {
+          "type": "text",
+          "id": "nqZ5t",
+          "x": 60,
+          "y": 2300,
+          "name": "imaTitle",
+          "fill": "#111827",
+          "content": "이마 — 현재 구현 (FrogMenuBarLabel)",
+          "fontFamily": "Inter",
+          "fontSize": 24,
+          "fontWeight": "600"
+        },
+        {
+          "type": "text",
+          "id": "Kiy86",
+          "x": 60,
+          "y": 2330,
+          "name": "imaCaption",
+          "fill": "#6B7280",
+          "content": "FrogTrayApp.swift 기준 · FrogStatusIcon(눈깔) + 이마글씨 · 4단계 배부름 상태",
+          "fontFamily": "Inter",
+          "fontSize": 14,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "frame",
+          "id": "H5dB5",
+          "x": 60,
+          "y": 2370,
+          "name": "imaCalm",
+          "width": 160,
+          "fill": "#FFFFFF",
+          "cornerRadius": 18,
+          "stroke": {
+            "thickness": 1,
+            "fill": "#E5E7EB"
+          },
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000010",
+            "offset": {
+              "x": 0,
+              "y": 8
+            },
+            "blur": 18
+          },
+          "layout": "vertical",
+          "gap": 10,
+          "padding": 14,
+          "children": [
+            {
+              "type": "text",
+              "id": "lWLpb",
+              "name": "imaCalm_title",
+              "fill": "#166534",
+              "content": "여유 · 0-39%",
+              "fontFamily": "Inter",
+              "fontSize": 15,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "adZqG",
+              "name": "imaCalm_hero",
+              "width": "fill_container",
+              "height": 80,
+              "fill": "#F0FDF4",
+              "cornerRadius": 12,
+              "layout": "none",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "amemX",
+                  "x": 16,
+                  "y": 4,
+                  "name": "eye",
+                  "fill": "#166534",
+                  "width": 14,
+                  "height": 14
+                },
+                {
+                  "type": "ellipse",
+                  "id": "o19M1",
+                  "x": 38,
+                  "y": 4,
+                  "name": "eye",
+                  "fill": "#166534",
+                  "width": 14,
+                  "height": 14
+                },
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 14,
+                  "id": "l5jN4",
+                  "x": 13,
+                  "y": 16,
+                  "name": "body",
+                  "fill": "#166534",
+                  "width": 40,
+                  "height": 28
+                },
+                {
+                  "type": "ellipse",
+                  "id": "uu44m",
+                  "x": 30,
+                  "y": 34,
+                  "name": "belly",
+                  "fill": "#4ADE80",
+                  "width": 18,
+                  "height": 12
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "5a9pZ",
+              "name": "imaCalm_menubar",
+              "width": "fill_container",
+              "height": 30,
+              "fill": "#111827",
+              "cornerRadius": 8,
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "68ggL",
+                  "name": "frogIcon",
+                  "width": 16,
+                  "height": 14,
+                  "layout": "none",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "ACxHL",
+                      "x": 2,
+                      "y": 0,
+                      "name": "fe1L",
+                      "fill": "#E5E7EB",
+                      "width": 4,
+                      "height": 4
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "az68R",
+                      "x": 10,
+                      "y": 0,
+                      "name": "fe1R",
+                      "fill": "#E5E7EB",
+                      "width": 4,
+                      "height": 4
+                    },
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 4,
+                      "id": "qMjpT",
+                      "x": 2,
+                      "y": 4,
+                      "name": "fb1",
+                      "fill": "#E5E7EB",
+                      "width": 11,
+                      "height": 8
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "XEYQ0",
+                      "x": 7,
+                      "y": 7,
+                      "name": "fbl1",
+                      "fill": "#4ADE80",
+                      "width": 5,
+                      "height": 3
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "i2Rwq",
+                  "name": "mt1",
+                  "fill": "#E5E7EB",
+                  "content": "C24 M19 D12",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "bvwYh",
+              "name": "imaCalm_note",
+              "fill": "#6B7280",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "배가 거의 납작\n눈깔 크기: 5×3.5",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "VkVh2",
+          "x": 240,
+          "y": 2370,
+          "name": "imaNormal",
+          "width": 160,
+          "fill": "#FFFFFF",
+          "cornerRadius": 18,
+          "stroke": {
+            "thickness": 1,
+            "fill": "#E5E7EB"
+          },
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000010",
+            "offset": {
+              "x": 0,
+              "y": 8
+            },
+            "blur": 18
+          },
+          "layout": "vertical",
+          "gap": 10,
+          "padding": 14,
+          "children": [
+            {
+              "type": "text",
+              "id": "6P9bj",
+              "name": "imaNormal_title",
+              "fill": "#A16207",
+              "content": "보통 · 40-64%",
+              "fontFamily": "Inter",
+              "fontSize": 15,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "c2LIc",
+              "name": "imaNormal_hero",
+              "width": "fill_container",
+              "height": 80,
+              "fill": "#FEFCE8",
+              "cornerRadius": 12,
+              "layout": "none",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "DWWTG",
+                  "x": 16,
+                  "y": 4,
+                  "name": "eye",
+                  "fill": "#A16207",
+                  "width": 14,
+                  "height": 14
+                },
+                {
+                  "type": "ellipse",
+                  "id": "MyrdL",
+                  "x": 38,
+                  "y": 4,
+                  "name": "eye",
+                  "fill": "#A16207",
+                  "width": 14,
+                  "height": 14
+                },
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 14,
+                  "id": "zGGco",
+                  "x": 13,
+                  "y": 16,
+                  "name": "body",
+                  "fill": "#A16207",
+                  "width": 40,
+                  "height": 28
+                },
+                {
+                  "type": "ellipse",
+                  "id": "6pJ7n",
+                  "x": 27,
+                  "y": 30,
+                  "name": "belly",
+                  "fill": "#FACC15",
+                  "width": 24,
+                  "height": 18
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "eZsE3",
+              "name": "imaNormal_menubar",
+              "width": "fill_container",
+              "height": 30,
+              "fill": "#111827",
+              "cornerRadius": 8,
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "CY1aA",
+                  "name": "frogIcon",
+                  "width": 16,
+                  "height": 14,
+                  "layout": "none",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "8U4h8",
+                      "x": 2,
+                      "y": 0,
+                      "name": "fe2L",
+                      "fill": "#E5E7EB",
+                      "width": 4,
+                      "height": 4
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "8XMO5",
+                      "x": 10,
+                      "y": 0,
+                      "name": "fe2R",
+                      "fill": "#E5E7EB",
+                      "width": 4,
+                      "height": 4
+                    },
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 4,
+                      "id": "TEds3",
+                      "x": 2,
+                      "y": 4,
+                      "name": "fb2",
+                      "fill": "#E5E7EB",
+                      "width": 11,
+                      "height": 8
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "oZjHC",
+                      "x": 6,
+                      "y": 6,
+                      "name": "fbl2",
+                      "fill": "#FACC15",
+                      "width": 6,
+                      "height": 5
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "UxmG7",
+                  "name": "mt2",
+                  "fill": "#E5E7EB",
+                  "content": "C43 M58 D37",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "sKgLb",
+              "name": "imaNormal_note",
+              "fill": "#6B7280",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "배가 살짝 도드라짐\n눈깔 크기: 6.5×5",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "YIPIH",
+          "x": 420,
+          "y": 2370,
+          "name": "imaWarning",
+          "width": 160,
+          "fill": "#FFFFFF",
+          "cornerRadius": 18,
+          "stroke": {
+            "thickness": 1,
+            "fill": "#E5E7EB"
+          },
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000010",
+            "offset": {
+              "x": 0,
+              "y": 8
+            },
+            "blur": 18
+          },
+          "layout": "vertical",
+          "gap": 10,
+          "padding": 14,
+          "children": [
+            {
+              "type": "text",
+              "id": "8ciG9",
+              "name": "imaWarning_title",
+              "fill": "#C2410C",
+              "content": "주의 · 65-84%",
+              "fontFamily": "Inter",
+              "fontSize": 15,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "kZO9C",
+              "name": "imaWarning_hero",
+              "width": "fill_container",
+              "height": 80,
+              "fill": "#FFF7ED",
+              "cornerRadius": 12,
+              "layout": "none",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "lbeMP",
+                  "x": 16,
+                  "y": 4,
+                  "name": "eye",
+                  "fill": "#C2410C",
+                  "width": 14,
+                  "height": 14
+                },
+                {
+                  "type": "ellipse",
+                  "id": "CuUHs",
+                  "x": 38,
+                  "y": 4,
+                  "name": "eye",
+                  "fill": "#C2410C",
+                  "width": 14,
+                  "height": 14
+                },
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 14,
+                  "id": "RWpJu",
+                  "x": 13,
+                  "y": 16,
+                  "name": "body",
+                  "fill": "#C2410C",
+                  "width": 40,
+                  "height": 28
+                },
+                {
+                  "type": "ellipse",
+                  "id": "jAsMH",
+                  "x": 24,
+                  "y": 27,
+                  "name": "belly",
+                  "fill": "#FB923C",
+                  "width": 30,
+                  "height": 24
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "tGhDb",
+              "name": "imaWarning_menubar",
+              "width": "fill_container",
+              "height": 30,
+              "fill": "#111827",
+              "cornerRadius": 8,
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "UV6xm",
+                  "name": "frogIcon",
+                  "width": 16,
+                  "height": 14,
+                  "layout": "none",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "dCiGR",
+                      "x": 2,
+                      "y": 0,
+                      "name": "fe3L",
+                      "fill": "#E5E7EB",
+                      "width": 4,
+                      "height": 4
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "iiMOf",
+                      "x": 10,
+                      "y": 0,
+                      "name": "fe3R",
+                      "fill": "#E5E7EB",
+                      "width": 4,
+                      "height": 4
+                    },
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 4,
+                      "id": "FoyqW",
+                      "x": 2,
+                      "y": 4,
+                      "name": "fb3",
+                      "fill": "#E5E7EB",
+                      "width": 11,
+                      "height": 8
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "JwUr6",
+                      "x": 5,
+                      "y": 5,
+                      "name": "fbl3",
+                      "fill": "#FB923C",
+                      "width": 8,
+                      "height": 6
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "Ckcg3",
+                  "name": "mt3",
+                  "fill": "#E5E7EB",
+                  "content": "C61 M74 D69",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "ffuAW",
+              "name": "imaWarning_note",
+              "fill": "#6B7280",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "배가 확실히 빵빵함\n눈깔 크기: 8×6.5",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "46Q7t",
+          "x": 600,
+          "y": 2370,
+          "name": "imaCritical",
+          "width": 160,
+          "fill": "#FFFFFF",
+          "cornerRadius": 18,
+          "stroke": {
+            "thickness": 1,
+            "fill": "#E5E7EB"
+          },
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000010",
+            "offset": {
+              "x": 0,
+              "y": 8
+            },
+            "blur": 18
+          },
+          "layout": "vertical",
+          "gap": 10,
+          "padding": 14,
+          "children": [
+            {
+              "type": "text",
+              "id": "gz9MP",
+              "name": "imaCritical_title",
+              "fill": "#B91C1C",
+              "content": "위험 · 85%+",
+              "fontFamily": "Inter",
+              "fontSize": 15,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "YqQb5",
+              "name": "imaCritical_hero",
+              "width": "fill_container",
+              "height": 80,
+              "fill": "#FEF2F2",
+              "cornerRadius": 12,
+              "layout": "none",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "qmtkB",
+                  "x": 16,
+                  "y": 4,
+                  "name": "eye",
+                  "fill": "#B91C1C",
+                  "width": 14,
+                  "height": 14
+                },
+                {
+                  "type": "ellipse",
+                  "id": "g5XmN",
+                  "x": 38,
+                  "y": 4,
+                  "name": "eye",
+                  "fill": "#B91C1C",
+                  "width": 14,
+                  "height": 14
+                },
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 14,
+                  "id": "jiZn5",
+                  "x": 13,
+                  "y": 16,
+                  "name": "body",
+                  "fill": "#B91C1C",
+                  "width": 40,
+                  "height": 28
+                },
+                {
+                  "type": "ellipse",
+                  "id": "8RZ40",
+                  "x": 21,
+                  "y": 24,
+                  "name": "belly",
+                  "fill": "#EF4444",
+                  "width": 36,
+                  "height": 30
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "gIYQp",
+              "name": "imaCritical_menubar",
+              "width": "fill_container",
+              "height": 30,
+              "fill": "#111827",
+              "cornerRadius": 8,
+              "gap": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "mQ1JR",
+                  "name": "frogIcon",
+                  "width": 16,
+                  "height": 14,
+                  "layout": "none",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "vvaoY",
+                      "x": 2,
+                      "y": 0,
+                      "name": "fe4L",
+                      "fill": "#E5E7EB",
+                      "width": 4,
+                      "height": 4
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "gyDj3",
+                      "x": 10,
+                      "y": 0,
+                      "name": "fe4R",
+                      "fill": "#E5E7EB",
+                      "width": 4,
+                      "height": 4
+                    },
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 4,
+                      "id": "83UCs",
+                      "x": 2,
+                      "y": 4,
+                      "name": "fb4",
+                      "fill": "#E5E7EB",
+                      "width": 11,
+                      "height": 8
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "6R5A3",
+                      "x": 4,
+                      "y": 4,
+                      "name": "fbl4",
+                      "fill": "#EF4444",
+                      "width": 9,
+                      "height": 8
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "rCKpP",
+                  "name": "mt4",
+                  "fill": "#E5E7EB",
+                  "content": "C88 M91 D92",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "6kF5C",
+              "name": "imaCritical_note",
+              "fill": "#6B7280",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "터질 듯 과장된 배\n눈깔 크기: 9.5×8",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "V05Ll",
+          "x": 60,
+          "y": 2360,
+          "name": "imaStructLabel",
+          "fill": "#374151",
+          "content": "이마 구조: HStack(spacing:4) { FrogStatusIcon(16×14) + Text(\"C{cpu}% M{mem}% D{disk}%\", .system(11, semibold, rounded)) }",
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "500"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- 메뉴바 라벨("이마")을 단순 개구리 실루엣 + 텍스트에서 **6단계 성장형 SF Symbol 캐릭터 + 히스토리 막대 그래프**로 전면 개편
- **AppKit 브릿지**를 통해 호버 툴팁(NSPopover)과 우클릭 컨텍스트 메뉴(NSMenu) 추가
- `PondTheme`/`UsageTone`을 별도 파일로 추출하고, `PondState`(6단계 연못 상태), `MetricsHistory`(순환 버퍼) 모델 도입

### 새 파일 (9개)
| 파일 | 역할 |
|------|------|
| `PondTheme.swift` | 색상 팔레트 추출 + 다크/라이트 변형 |
| `PondState.swift` | 6단계 상태 enum + SF Symbol 매핑 |
| `MetricsHistory.swift` | 최근 3회 수치 순환 버퍼 |
| `MenuBarCharacterView.swift` | 호흡/깜빡임/상태별 모션 애니메이션 캐릭터 |
| `MenuBarHistoryBarsView.swift` | C/M/D 미니 막대 그래프 |
| `MenuBarContextMenu.swift` | 우클릭 NSMenu 빌더 |
| `MenuBarTooltipView.swift` | 호버 미니 대시보드 |
| `MenuBarHostingBridge.swift` | AppKit 브릿지 (hover/tooltip/right-click) |
| `MenuBarLabelView.swift` | 캐릭터 + 막대 + 브릿지 조합 |

### 수정 파일 (3개)
- `FrogTrayApp.swift` — `FrogMenuBarLabel`/`FrogStatusIcon` 제거 → `MenuBarLabelView` 교체
- `SystemMetricsMonitor.swift` — `metricsHistory`, `pondState` 추가
- `ContentView.swift` — `PondTheme`/`UsageTone` 추출, `FrogStatusIcon` private 인라인

## Test plan
- [ ] Xcode 빌드 성공 확인 (Debug/Release)
- [ ] 메뉴바에서 SF Symbol 캐릭터 + 막대 그래프 표시 확인
- [ ] 시스템 부하에 따른 캐릭터 변화 확인 (sleeping → danger)
- [ ] 호버 시 미니 대시보드 팝오버 표시 확인
- [ ] 우클릭 컨텍스트 메뉴 동작 확인
- [ ] 다크/라이트 모드 전환 시 캐릭터 색상 변경 확인
- [ ] Reduce Motion 켜고 애니메이션 비활성화 확인
- [ ] VoiceOver로 접근성 라벨 읽기 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)